### PR TITLE
J conq tinkering

### DIFF
--- a/NGUInjector/AllocationProfiles/CustomAllocation.cs
+++ b/NGUInjector/AllocationProfiles/CustomAllocation.cs
@@ -51,7 +51,7 @@ namespace NGUInjector.AllocationProfiles
                     var text = File.ReadAllText(_allocationPath);
                     var parsed = JSON.Parse(text);
                     var breakpoints = parsed["Breakpoints"];
-                    _wrapper = new BreakpointWrapper {Breakpoints = new Breakpoints()};
+                    _wrapper = new BreakpointWrapper { Breakpoints = new Breakpoints() };
                     var rb = breakpoints["Rebirth"];
                     var rbtime = breakpoints["RebirthTime"];
                     if (rb == null)
@@ -68,10 +68,11 @@ namespace NGUInjector.AllocationProfiles
                         _wrapper.Breakpoints.Rebirth = BaseRebirth.CreateRebirth(target, type, rb["Challenges"].AsArray.Children.Select(x => x.Value.ToUpper()).ToArray());
                     }
 
-                    _wrapper.Breakpoints.ConsumablesBreakpoints = breakpoints["Consumables"].Children.Select(bp => new ConsumablesBreakpoint {
-                            Time = ParseTime(bp["Time"]),
-                            Consumables = ParseConsumableItemNames(bp["Items"].AsArray.Children.Select(x => x.Value.ToUpper()).ToArray()),
-                            Quantity = GetConsumablesQuantities(bp["Items"].AsArray.Children.Select(x => x.Value.ToUpper()).ToArray())
+                    _wrapper.Breakpoints.ConsumablesBreakpoints = breakpoints["Consumables"].Children.Select(bp => new ConsumablesBreakpoint
+                    {
+                        Time = ParseTime(bp["Time"]),
+                        Consumables = ParseConsumableItemNames(bp["Items"].AsArray.Children.Select(x => x.Value.ToUpper()).ToArray()),
+                        Quantity = GetConsumablesQuantities(bp["Items"].AsArray.Children.Select(x => x.Value.ToUpper()).ToArray())
                     }).OrderByDescending(x => x.Time).ToArray();
 
 
@@ -112,11 +113,11 @@ namespace NGUInjector.AllocationProfiles
                         }).OrderByDescending(x => x.Time).ToArray();
 
                     _wrapper.Breakpoints.Wandoos = breakpoints["Wandoos"].Children
-                        .Select(bp => new WandoosBreakpoint {Time = ParseTime(bp["Time"]), OS = bp["OS"].AsInt})
+                        .Select(bp => new WandoosBreakpoint { Time = ParseTime(bp["Time"]), OS = bp["OS"].AsInt })
                         .OrderByDescending(x => x.Time).ToArray();
 
                     _wrapper.Breakpoints.NGUBreakpoints = breakpoints["NGUDiff"].Children
-                        .Select(bp => new NGUDiffBreakpoint {Time = ParseTime(bp["Time"]), Diff = bp["Diff"].AsInt})
+                        .Select(bp => new NGUDiffBreakpoint { Time = ParseTime(bp["Time"]), Diff = bp["Diff"].AsInt })
                         .Where(x => x.Diff <= 2).OrderByDescending(x => x.Time).ToArray();
 
                     Main.Log(BuildAllocationString());
@@ -289,13 +290,16 @@ namespace NGUInjector.AllocationProfiles
             if (rb is NoRebirth)
             {
                 builder.AppendLine($"Rebirth Disabled.");
-            }else if (rb is NumberRebirth nrb)
+            }
+            else if (rb is NumberRebirth nrb)
             {
                 builder.AppendLine($"Rebirthing when number bonus is {nrb.MultTarget}x previous number");
-            }else if (rb is TimeRebirth trb)
+            }
+            else if (rb is TimeRebirth trb)
             {
                 builder.AppendLine($"Rebirthing at {trb.RebirthTime} seconds");
-            }else if (rb is BossNumRebirth brb)
+            }
+            else if (rb is BossNumRebirth brb)
             {
                 builder.AppendLine($"Rebirthing when number allows you +{brb.NumBosses} bosses");
             }
@@ -442,115 +446,20 @@ namespace NGUInjector.AllocationProfiles
 
         public void CastBloodSpells()
         {
-            CastBloodSpells(false);
-        }
-
-        public void CastBloodSpells(bool rebirth)
-        {
             if (!Main.Settings.CastBloodSpells)
                 return;
 
             if (_wrapper.Breakpoints.Rebirth is TimeRebirth trb && Main.Settings.AutoRebirth)
             {
-                if (trb.RebirthTime - _character.rebirthTime.totalseconds < 30 * 60 && !rebirth)
+                if (trb.RebirthTime - _character.rebirthTime.totalseconds < 30 * 60)// && !rebirth)
                 {
                     return;
                 }
             }
 
-            float iron = 0;
-            long mcguffA = 0;
-            long mcguffB = 0;
-            if (Main.Settings.BloodMacGuffinBThreshold > 0)
-            {
-                if (_character.adventure.itopod.perkLevel[73] >= 1L &&
-                    _character.settings.rebirthDifficulty >= difficulty.evil)
-                {
-                    if (_character.bloodMagic.macguffin2Time.totalseconds > _character.bloodMagicController.spells.macguffin2Cooldown)
-                    {
-                        if (_character.bloodMagic.bloodPoints >= _character.bloodSpells.minMacguffin2Blood())
-                        {
-                            var a = _character.bloodMagic.bloodPoints / _character.bloodSpells.minMacguffin2Blood();
-                            mcguffB = (int) (Math.Log(a, 20.0) + 1.0);
-                        }
-
-                        if (Main.Settings.BloodMacGuffinBThreshold <= mcguffB)
-                        {
-                            _character.bloodSpells.castMacguffin2Spell();
-                            Main.LogPitSpin("Casting Blood MacGuffin B Spell power @ " + mcguffB);
-                            return;
-                        }
-                        else
-                        {
-                            if (rebirth)
-                            {
-                                Main.Log("Casting Failed Blood MacGuffin B Spell - Insufficient Power " + mcguffB +
-                                         " of " + Main.Settings.BloodMacGuffinBThreshold);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (Main.Settings.BloodMacGuffinAThreshold > 0)
-            {
-                if (_character.adventure.itopod.perkLevel[72] >= 1L)
-                {
-                    if (_character.bloodMagic.macguffin1Time.totalseconds >= _character.bloodMagicController.spells.macguffin1Cooldown)
-                    {
-                        if (_character.bloodMagic.bloodPoints > _character.bloodSpells.minMacguffin1Blood())
-                        {
-                            var a = _character.bloodMagic.bloodPoints / _character.bloodSpells.minMacguffin1Blood();
-                            mcguffA = (int) ((Math.Log(a, 10.0) + 1.0) *
-                                             _character.wishesController.totalBloodGuffbonus());
-                        }
-                        if (Main.Settings.BloodMacGuffinAThreshold <= mcguffA)
-                        {
-                            _character.bloodSpells.castMacguffin1Spell();
-                            Main.LogPitSpin("Casting Blood MacGuffin A Spell power @ " + mcguffA);
-                            return;
-                        }
-                        else
-                        {
-                            if (rebirth)
-                            {
-                                Main.Log("Casting Failed Blood MacGuffin A Spell - Insufficient Power " + mcguffA +
-                                         " of " + Main.Settings.BloodMacGuffinAThreshold);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (Main.Settings.IronPillThreshold > 100)
-            {
-                if (_character.bloodMagic.adventureSpellTime.totalseconds >
-                    _character.bloodSpells.adventureSpellCooldown)
-                {
-                    if (_character.bloodMagic.bloodPoints > _character.bloodSpells.minAdventureBlood())
-                    {
-                        iron = (float) Math.Floor(Math.Pow(_character.bloodMagic.bloodPoints, 0.25));
-                        if (_character.settings.rebirthDifficulty >= difficulty.evil)
-                        {
-                            iron *= _character.adventureController.itopod.ironPillBonus();
-                        }
-                    }
-
-                    if (Main.Settings.IronPillThreshold <= iron)
-                    {
-                        _character.bloodSpells.castAdventurePowerupSpell();
-                        Main.LogPitSpin("Casting Iron Blood Spell power @ " + iron);
-                    }
-                    else
-                    {
-                        if (rebirth)
-                        {
-                            Main.Log("Casting Failed Iron Blood Spell - Insufficient Power " + iron + " of " +
-                                     Main.Settings.IronPillThreshold);
-                        }
-                    }
-                }
-            }
+            BloodMagicManager.CastGuffB(false);
+            BloodMagicManager.CastGuffA(false);
+            BloodMagicManager.CastIronPill(false);
         }
 
         public override void AllocateEnergy()
@@ -696,10 +605,10 @@ namespace NGUInjector.AllocationProfiles
             var temp = bp.Priorities.Where(x => x.IsValid()).ToList();
             if (temp.Count == 0)
                 return;
-            
+
             var prioCount = temp.Count(x => !x.IsCapPrio() && !(x is HackBP)) + (temp.Any(x => x is HackBP && !x.IsCapPrio()) ? 1 : 0);
             _character.removeAllRes3();
-            var toAdd = (long) Math.Ceiling((double) _character.res3.idleRes3 / prioCount);
+            var toAdd = (long)Math.Ceiling((double)_character.res3.idleRes3 / prioCount);
             SetInput(toAdd);
 
             var hackAllocated = false;
@@ -769,10 +678,23 @@ namespace NGUInjector.AllocationProfiles
             if (_hasDiggerSwapped) return;
 
             if (!DiggerManager.CanSwap()) return;
-            _hasDiggerSwapped = true;
-            _currentDiggerBreakpoint = bp;
 
-            DiggerManager.EquipDiggers(bp.Diggers);
+            //Main.LogDebug($"Setting diggers from bp {bp.Time}: {string.Join(",", bp.Diggers.Select(x => x.ToString()))}");
+            
+            _hasDiggerSwapped = DiggerManager.TryEquipDiggers(bp.Diggers);
+            
+            //Main.LogDebug($"Result: {_hasDiggerSwapped}");
+
+            if (_hasDiggerSwapped)
+            {
+                Main.Log($"Equipping Diggers: {string.Join(",", bp.Diggers.Select(x => x.ToString()))}");
+                _currentDiggerBreakpoint = bp;
+            }
+            else
+            {
+                //Main.LogDebug($"Not all configured diggers enabled, retry at next loop...");
+            }
+
             _character.allDiggers.refreshMenu();
         }
 
@@ -787,7 +709,7 @@ namespace NGUInjector.AllocationProfiles
             {
                 _didConsumeConsumables = false;
             }
-            
+
             if (_didConsumeConsumables) return;
             _didConsumeConsumables = true;
             _currentConsumablesBreakpoint = bp;

--- a/NGUInjector/AllocationProfiles/RebirthStuff/BaseRebirth.cs
+++ b/NGUInjector/AllocationProfiles/RebirthStuff/BaseRebirth.cs
@@ -48,7 +48,7 @@ namespace NGUInjector.AllocationProfiles.RebirthStuff
                     RebirthTime = target
                 };
             }
-            
+
             if (type == "NUMBER")
             {
                 return new NumberRebirth
@@ -325,115 +325,31 @@ namespace NGUInjector.AllocationProfiles.RebirthStuff
 
             DiggerManager.UpgradeCheapestDigger();
 
-            CastBloodSpells(true);
+            CastBloodSpellsForRebirth();
             return false;
         }
 
-        protected void CastBloodSpells(bool rebirth)
+        protected void CastBloodSpellsForRebirth()
         {
             if (!Main.Settings.CastBloodSpells)
                 return;
 
-            float iron = 0;
-            long mcguffA = 0;
-            long mcguffB = 0;
-            if (Main.Settings.BloodMacGuffinBThreshold > 0)
-            {
-                if (CharObj.adventure.itopod.perkLevel[73] >= 1L &&
-                    CharObj.settings.rebirthDifficulty >= difficulty.evil)
-                {
-                    if (CharObj.bloodMagic.macguffin2Time.totalseconds > CharObj.bloodSpells.macguffin2Cooldown)
-                    {
-                        if (CharObj.bloodMagic.bloodPoints >= CharObj.bloodSpells.minMacguffin2Blood())
-                        {
-                            var a = CharObj.bloodMagic.bloodPoints / CharObj.bloodSpells.minMacguffin2Blood();
-                            mcguffB = (int)(Math.Log(a, 20.0) + 1.0);
-                        }
+            BloodMagicManager.CastGuffB(true);
 
-                        if (Main.Settings.BloodMacGuffinBThreshold <= mcguffB)
-                        {
-                            CharObj.bloodSpells.castMacguffin2Spell();
-                            Main.LogPitSpin("Casting Blood MacGuffin B Spell power @ " + mcguffB);
-                            return;
-                        }
-                        else
-                        {
-                            if (rebirth)
-                            {
-                                Main.Log("Casting Failed Blood MacGuffin B Spell - Insufficient Power " + mcguffB +
-                                         " of " + Main.Settings.BloodMacGuffinBThreshold);
-                            }
-                        }
-                    }
-                }
+            if (Main.Character.bloodMagic.bloodPoints > 0)
+            {
+                BloodMagicManager.CastGuffA(true);
             }
 
-            if (Main.Settings.BloodMacGuffinAThreshold > 0)
+            if (Main.Character.bloodMagic.bloodPoints > 0)
             {
-                if (CharObj.adventure.itopod.perkLevel[72] >= 1L)
-                {
-                    if (CharObj.bloodMagic.macguffin1Time.totalseconds > CharObj.bloodSpells.macguffin1Cooldown)
-                    {
-                        if (CharObj.bloodMagic.bloodPoints > CharObj.bloodSpells.minMacguffin1Blood())
-                        {
-                            var a = CharObj.bloodMagic.bloodPoints / CharObj.bloodSpells.minMacguffin1Blood();
-                            mcguffA = (int)((Math.Log(a, 10.0) + 1.0) *
-                                             CharObj.wishesController.totalBloodGuffbonus());
-                        }
-
-                        if (Main.Settings.BloodMacGuffinAThreshold <= mcguffA)
-                        {
-                            CharObj.bloodSpells.castMacguffin1Spell();
-                            Main.LogPitSpin("Casting Blood MacGuffin A Spell power @ " + mcguffA);
-                            return;
-                        }
-                        else
-                        {
-                            if (rebirth)
-                            {
-                                Main.Log("Casting Failed Blood MacGuffin A Spell - Insufficient Power " + mcguffA +
-                                         " of " + Main.Settings.BloodMacGuffinAThreshold);
-                            }
-                        }
-                    }
-                }
+                BloodMagicManager.CastIronPill(true);
             }
 
-            if (Main.Settings.IronPillThreshold > 100)
+            // Use whatever blood we have left on blood number before rebirthing
+            if (Main.Character.bloodMagic.bloodPoints > 0)
             {
-                if (CharObj.bloodMagic.adventureSpellTime.totalseconds >
-                    CharObj.bloodSpells.adventureSpellCooldown)
-                {
-                    if (CharObj.bloodMagic.bloodPoints > CharObj.bloodSpells.minAdventureBlood())
-                    {
-                        iron = (float)Math.Floor(Math.Pow(CharObj.bloodMagic.bloodPoints, 0.25));
-                        if (CharObj.settings.rebirthDifficulty >= difficulty.evil)
-                        {
-                            iron *= CharObj.adventureController.itopod.ironPillBonus();
-                        }
-                    }
-
-                    if (Main.Settings.IronPillThreshold <= iron)
-                    {
-                        CharObj.bloodSpells.castAdventurePowerupSpell();
-                        Main.LogPitSpin("Casting Iron Blood Spell power @ " + iron);
-                    }
-                    else
-                    {
-                        if (rebirth)
-                        {
-                            Main.Log("Casting Failed Iron Blood Spell - Insufficient Power " + iron + " of " +
-                                     Main.Settings.IronPillThreshold);
-                        }
-                    }
-                }
-            }
-
-
-            if (rebirth)
-            {
-                // Use whatever blood we have left on blood number before rebirthing
-                Main.Log("Casting number blood spell before rebirth");
+                Main.Log($"Casting number blood spell with remaining {Main.Character.bloodMagic.bloodPoints} blood before rebirth");
                 CharObj.bloodSpells.castRebirthSpell();
             }
         }

--- a/NGUInjector/Extensions.cs
+++ b/NGUInjector/Extensions.cs
@@ -22,7 +22,7 @@ namespace NGUInjector
         public static ih MaxItem(this IEnumerable<ih> items)
         {
             return items.Aggregate(
-                new { max = int.MinValue, t = (ih)null, b = decimal.MaxValue },
+                new { max = int.MinValue, t = (ih)null, b = float.MaxValue },
                 (state, el) =>
                 {
                     var current = el.locked ? el.level + 101 : el.level;
@@ -100,22 +100,22 @@ namespace NGUInjector
             var n = new BoostsNeeded();
 
             if (eq.capAttack != 0.0)
-                n.Power += CalcCap(eq.capAttack, eq.level) - (decimal)eq.curAttack;
+                n.Power += Math.Max(CalcCap(eq.capAttack, eq.level) - eq.curAttack, 0f);
 
             if (eq.capDefense != 0.0)
-                n.Toughness += CalcCap(eq.capDefense, eq.level) - (decimal)eq.curDefense;
+                n.Toughness += Math.Max(CalcCap(eq.capDefense, eq.level) - eq.curDefense, 0f);
 
             if (Settings.SpecialBoostBlacklist.Contains(eq.id))
                 return n;
 
             if (eq.spec1Type != specType.None)
-                n.Special += CalcCap(eq.spec1Cap, eq.level) - (decimal)eq.spec1Cur;
+                n.Special += Math.Max(CalcCap(eq.spec1Cap, eq.level) - eq.spec1Cur, 0f);
 
             if (eq.spec2Type != specType.None)
-                n.Special += CalcCap(eq.spec2Cap, eq.level) - (decimal)eq.spec2Cur;
+                n.Special += Math.Max(CalcCap(eq.spec2Cap, eq.level) - eq.spec2Cur, 0f);
 
             if (eq.spec3Type != specType.None)
-                n.Special += CalcCap(eq.spec3Cap, eq.level) - (decimal)eq.spec3Cur;
+                n.Special += Math.Max(CalcCap(eq.spec3Cap, eq.level) - eq.spec3Cur, 0f);
 
             return n;
         }
@@ -198,9 +198,9 @@ namespace NGUInjector
             return (float)num;
         }
 
-        private static decimal CalcCap(float cap, float level)
+        internal static float CalcCap(float cap, int level)
         {
-            return (decimal)Mathf.Floor(cap * (float)(1.0 + level / 100.0));
+            return Mathf.Floor(cap * (1f + (float)level / 100f));
         }
 
         internal static void DoAllocations(this CustomAllocation allocation)

--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -40,6 +40,7 @@ namespace NGUInjector
         private CardManager _cardManager;
         private CookingManager _cookingManager;
         private ConsumablesManager _consumablesManager;
+        private BloodMagicManager _bloodManager;
         private static CustomAllocation _profile;
         private float _timeLeft = 10.0f;
         internal static SettingsForm settingsForm;
@@ -198,6 +199,7 @@ namespace NGUInjector
                 _cardManager = new CardManager();
                 _cookingManager = new CookingManager();
                 _consumablesManager = new ConsumablesManager();
+                _bloodManager = new BloodMagicManager();
                 LoadoutManager.ReleaseLock();
                 DiggerManager.ReleaseLock();
 
@@ -253,6 +255,9 @@ namespace NGUInjector
                         IronPillThreshold = 10000,
                         BloodMacGuffinAThreshold = 6,
                         BloodMacGuffinBThreshold = 6,
+                        IronPillOnRebirth = false,
+                        BloodMacGuffinAOnRebirth = false,
+                        BloodMacGuffinBOnRebirth = false,
                         CubePriority = 0,
                         CombatEnabled = false,
                         GlobalEnabled = false,

--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -1170,6 +1170,10 @@ namespace NGUInjector
 
         private void SnipeZone()
         {
+            CombatHelpers.IsCurrentlyGoldSniping = false;
+            CombatHelpers.IsCurrentlyQuesting = false;
+            CombatHelpers.IsCurrentlyAdventuring = false;
+
             if (!Settings.GlobalEnabled)
                 return;
 
@@ -1187,6 +1191,7 @@ namespace NGUInjector
                 if (Character.machine.realBaseGold == 0.0)
                 {
                     _combManager.ManualZone(0, false, false, false, true, false);
+                    CombatHelpers.IsCurrentlyGoldSniping = true;
                     return;
                 }
                 //Go to our gold loadout zone next to get a high gold drop
@@ -1198,16 +1203,15 @@ namespace NGUInjector
                         _furthestZone = ZoneHelpers.GetMaxReachableZone(false);
 
                         _combManager.ManualZone(bestZone.Zone, true, bestZone.FightType == 1, false, bestZone.FightType == 2, false);
+                        CombatHelpers.IsCurrentlyGoldSniping = true;
                         return;
                     }
                 }
             }
 
             var questZone = _questManager.IsQuesting();
-            if (!Settings.CombatEnabled || Settings.AdventureTargetITOPOD || !ZoneHelpers.ZoneIsTitan(Settings.SnipeZone) ||
-                !CombatManager.IsZoneUnlocked(Settings.SnipeZone) ||
-                ZoneHelpers.ZoneIsTitan(Settings.SnipeZone) &&
-                !ZoneHelpers.TitanSpawningSoon(Array.IndexOf(ZoneHelpers.TitanZones, Settings.SnipeZone)))
+            if (!Settings.CombatEnabled || Settings.AdventureTargetITOPOD || !CombatManager.IsZoneUnlocked(Settings.SnipeZone) || !ZoneHelpers.ZoneIsTitan(Settings.SnipeZone) ||
+                (ZoneHelpers.ZoneIsTitan(Settings.SnipeZone) && !ZoneHelpers.TitanSpawningSoon(Array.IndexOf(ZoneHelpers.TitanZones, Settings.SnipeZone))))
             {
                 if (questZone > 0)
                 {
@@ -1220,6 +1224,7 @@ namespace NGUInjector
                         _combManager.IdleZone(questZone, false, false);
                     }
 
+                    CombatHelpers.IsCurrentlyQuesting = true;
                     return;
                 }
             }
@@ -1254,6 +1259,7 @@ namespace NGUInjector
                     _combManager.IdleZone(tempZone, false, Settings.ITOPODRecoverHP);
                 }
 
+                CombatHelpers.IsCurrentlyAdventuring = true;
                 return;
             }
 
@@ -1265,6 +1271,7 @@ namespace NGUInjector
             {
                 _combManager.IdleZone(tempZone, Settings.SnipeBossOnly, Settings.RecoverHealth);
             }
+            CombatHelpers.IsCurrentlyAdventuring = true;
         }
 
         private void MoveToITOPOD()
@@ -1404,7 +1411,7 @@ namespace NGUInjector
 
         public void ResetBoostProgress()
         {
-
+            _invManager.Reset();
         }
     }
 }

--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -1411,6 +1411,7 @@ namespace NGUInjector
 
         public void ResetBoostProgress()
         {
+            Log($"Resetting Boost Average");
             _invManager.Reset();
         }
     }

--- a/NGUInjector/Managers/BloodMagicManager.cs
+++ b/NGUInjector/Managers/BloodMagicManager.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NGUInjector.Managers
+{
+    internal class BloodMagicManager
+    {
+        private readonly Character _character;
+        private enum FailureReason { Disabled, OnCooldown, BelowMinimum, BelowThreshold }
+
+        public BloodMagicManager()
+        {
+            _character = Main.Character;
+        }
+
+        private static string GetFailureMessage(FailureReason reason, double minBlood, double calculatedPower, int threshold)
+        {
+            string msg = string.Empty;
+
+            switch (reason)
+            {
+                case FailureReason.Disabled:
+                    msg = "Disabled";
+                    break;
+                case FailureReason.OnCooldown:
+                    msg = "On cooldown";
+                    break;
+                case FailureReason.BelowMinimum:
+                    msg = $"Below minimum blood threshold of {minBlood}";
+                    break;
+                case FailureReason.BelowThreshold:
+                    msg = $"Below configured power threshold ({Math.Round(calculatedPower, 2)} of {threshold}) and not force cast on rebirth";
+                    break;
+                default:
+                    msg = "Unknown";
+                    break;
+            }
+
+            return msg;
+        }
+
+        internal static void CastGuffB(bool rebirth)
+        {
+            if (!Main.Settings.CastBloodSpells)
+                return;
+
+            double bloodPoints = Main.Character.bloodMagic.bloodPoints;
+            double minBlood = Main.Character.bloodSpells.minMacguffin2Blood();
+
+            long mcguffB = 0;
+            FailureReason reason = FailureReason.Disabled;
+
+            if (Main.Settings.BloodMacGuffinBThreshold > 0)
+            {
+                if (Main.Character.adventure.itopod.perkLevel[73] >= 1L &&
+                    Main.Character.settings.rebirthDifficulty >= difficulty.evil)
+                {
+                    if (Main.Character.bloodMagic.macguffin2Time.totalseconds > Main.Character.bloodSpells.macguffin2Cooldown)
+                    {
+                        if (bloodPoints >= minBlood)
+                        {
+                            var a = bloodPoints / minBlood;
+                            mcguffB = (int)(Math.Log(a, 20.0) + 1.0);
+
+                            if (Main.Settings.BloodMacGuffinBThreshold <= mcguffB || (rebirth && Main.Settings.BloodMacGuffinBOnRebirth))
+                            {
+                                Main.Character.bloodSpells.castMacguffin2Spell();
+                                Main.LogPitSpin("Casting Blood MacGuffin B Spell power @ " + mcguffB);
+                                return;
+                            }
+                            else
+                            {
+                                reason = FailureReason.BelowThreshold;
+                            }
+                        }
+                        else
+                        {
+                            reason = FailureReason.BelowMinimum;
+                        }
+                    }
+                    else
+                    {
+                        reason = FailureReason.OnCooldown;
+                    }
+                }
+            }
+
+            if (rebirth)
+            {
+                string msg = $"Casting Failed Blood MacGuffin B Spell - {GetFailureMessage(reason, minBlood, mcguffB, Main.Settings.BloodMacGuffinBThreshold)}";
+                Main.Log(msg);
+            }
+        }
+
+        internal static void CastGuffA(bool rebirth)
+        {
+            if (!Main.Settings.CastBloodSpells)
+                return;
+
+            double bloodPoints = Main.Character.bloodMagic.bloodPoints;
+            double minBlood = Main.Character.bloodSpells.minMacguffin1Blood();
+
+            long mcguffA = 0;
+            FailureReason reason = FailureReason.Disabled;
+
+            if (Main.Settings.BloodMacGuffinAThreshold > 0)
+            {
+                if (Main.Character.adventure.itopod.perkLevel[72] >= 1L)
+                {
+                    if (Main.Character.bloodMagic.macguffin1Time.totalseconds > Main.Character.bloodSpells.macguffin1Cooldown)
+                    {
+                        if (bloodPoints >= minBlood)
+                        {
+                            var a = bloodPoints / minBlood;
+                            mcguffA = (int)((Math.Log(a, 10.0) + 1.0) * Main.Character.wishesController.totalBloodGuffbonus());
+
+                            if (Main.Settings.BloodMacGuffinAThreshold <= mcguffA || (rebirth && Main.Settings.BloodMacGuffinBOnRebirth))
+                            {
+                                Main.Character.bloodSpells.castMacguffin1Spell();
+                                Main.LogPitSpin("Casting Blood MacGuffin A Spell power @ " + mcguffA);
+                                return;
+                            }
+                            else
+                            {
+                                reason = FailureReason.BelowThreshold;
+                            }
+                        }
+                        else
+                        {
+                            reason = FailureReason.BelowMinimum;
+                        }
+                    }
+                    else
+                    {
+                        reason = FailureReason.OnCooldown;
+                    }
+                }
+            }
+
+            if (rebirth)
+            {
+                string msg = $"Casting Failed Blood MacGuffin A Spell - {GetFailureMessage(reason, minBlood, mcguffA, Main.Settings.BloodMacGuffinAThreshold)}";
+                Main.Log(msg);
+            }
+        }
+
+        internal static void CastIronPill(bool rebirth)
+        {
+            if (!Main.Settings.CastBloodSpells)
+                return;
+
+            double bloodPoints = Main.Character.bloodMagic.bloodPoints;
+            double minBlood = Main.Character.bloodSpells.minAdventureBlood();
+
+            float iron = 0;
+            FailureReason reason = FailureReason.Disabled;
+
+            if (Main.Settings.IronPillThreshold > 0)
+            {
+                if (Main.Character.bloodMagic.adventureSpellTime.totalseconds > Main.Character.bloodSpells.adventureSpellCooldown)
+                {
+                    if (bloodPoints >= minBlood)
+                    {
+                        iron = (float)Math.Floor(Math.Pow(bloodPoints, 0.25));
+                        if (Main.Character.settings.rebirthDifficulty >= difficulty.evil)
+                        {
+                            iron *= Main.Character.adventureController.itopod.ironPillBonus();
+                        }
+
+                        if (Main.Settings.IronPillThreshold <= iron || (rebirth && Main.Settings.IronPillOnRebirth))
+                        {
+                            Main.Character.bloodSpells.castAdventurePowerupSpell();
+                            Main.LogPitSpin("Casting Iron Blood Spell power @ " + iron);
+                            return;
+                        }
+                        else
+                        {
+                            reason = FailureReason.BelowThreshold;
+                        }
+                    }
+                    else
+                    {
+                        reason = FailureReason.BelowMinimum;
+                    }
+                }
+                else
+                {
+                    reason = FailureReason.OnCooldown;
+                }
+            }
+
+            if (rebirth)
+            {
+                string msg = $"Casting Failed Blood Iron Pill Spell - {GetFailureMessage(reason, minBlood, iron, Main.Settings.IronPillThreshold)}";
+                Main.Log(msg);
+            }
+        }
+    }
+}

--- a/NGUInjector/Managers/CombatHelpers.cs
+++ b/NGUInjector/Managers/CombatHelpers.cs
@@ -2,12 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime;
 using System.Text;
 
 namespace NGUInjector.Managers
 {
     internal static class CombatHelpers
     {
+        private static int _currentCombatZone = -1;
+        internal static int CurrentCombatZone
+        {
+            get { return IsCurrentlyGoldSniping || IsCurrentlyQuesting || IsCurrentlyAdventuring ? _currentCombatZone : -1; }
+            set { _currentCombatZone = value; }
+        }
+
+        internal static bool IsCurrentlyGoldSniping { get; set; }
+        internal static bool IsCurrentlyQuesting { get; set; }
+        internal static bool IsCurrentlyAdventuring { get; set; }
+
         internal static bool CastCharge()
         {
             if (Main.Character.adventureController.chargeMove.button.IsInteractable())
@@ -31,7 +43,7 @@ namespace NGUInjector.Managers
         }
 
         internal static bool ChargeReady()
-        { 
+        {
             return Main.Character.adventureController.chargeMove.button.IsInteractable();
         }
 

--- a/NGUInjector/Managers/DiggerManager.cs
+++ b/NGUInjector/Managers/DiggerManager.cs
@@ -12,7 +12,7 @@ namespace NGUInjector.Managers
 
         internal static LockType CurrentLock { get; set; }
         private static readonly int[] TitanDiggers = { 0, 3, 8, 11 };
-        private static readonly int[] YggDiggers = {8, 11};
+        private static readonly int[] YggDiggers = { 8, 11 };
 
         internal static bool CanSwap()
         {
@@ -44,7 +44,7 @@ namespace NGUInjector.Managers
 
         internal static bool TryYggSwap()
         {
-            if (!CanAcquireOrHasLock(LockType.Yggdrasil)) 
+            if (!CanAcquireOrHasLock(LockType.Yggdrasil))
                 return false;
 
             if (CurrentLock == LockType.Yggdrasil)
@@ -96,16 +96,33 @@ namespace NGUInjector.Managers
 
         internal static void EquipDiggers(int[] diggers)
         {
-            Main.Log($"Equipping Diggers: {string.Join(",", diggers.Select(x => x.ToString()).ToArray())}");
+            Main.Log($"Equipping Diggers: {string.Join(",", diggers.Select(x => x.ToString()))}");
+            TryEquipDiggers(diggers);
+        }
+
+        internal static bool TryEquipDiggers(int[] diggers)
+        {
             Main.Character.allDiggers.clearAllActiveDiggers();
             var sorted = diggers.OrderByDescending(x => x).Where(x => x <= 11 && x >= 0).ToArray();
+
+            bool allEquipped = true;
+
             for (var i = 0; i < sorted.Length; i++)
             {
-                if (Main.Character.diggers.diggers[i].maxLevel <= 0)
+                if (Main.Character.diggers.diggers[sorted[i]].maxLevel <= 0)
+                {
                     continue;
+                }
+
                 Main.Character.allDiggers.setLevelMaxAffordable(sorted[i]);
+
+                //Main.LogDebug($"Digger {sorted[i]} level: {Main.Character.diggers.diggers[sorted[i]].curLevel} active:{Main.Character.diggers.diggers[sorted[i]].active}");
+
+                allEquipped &= Main.Character.diggers.diggers[sorted[i]].active;
             }
+
             UpdateCheapestDigger();
+            return allEquipped;
         }
 
         private static bool CanAcquireOrHasLock(LockType requestor)
@@ -127,7 +144,7 @@ namespace NGUInjector.Managers
         {
             var gross = Main.Character.grossGoldPerSecond();
             var sub = 0.0;
-            for (var i = Main.Character.diggers.diggers.Count-1; i >= 0 ; i--)
+            for (var i = Main.Character.diggers.diggers.Count - 1; i >= 0; i--)
             {
                 if (Main.Character.diggers.diggers[i].active)
                 {

--- a/NGUInjector/Managers/InventoryManager.cs
+++ b/NGUInjector/Managers/InventoryManager.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using static NGUInjector.Main;
+using static System.Resources.ResXFileRef;
 
 namespace NGUInjector.Managers
 {
 
     public class FixedSizedQueue
     {
-        private Queue<decimal> queue = new Queue<decimal>();
+        private Queue<float> queue = new Queue<float>();
 
         public int Size { get; private set; }
 
@@ -18,7 +19,7 @@ namespace NGUInjector.Managers
             Size = size;
         }
 
-        public void Enqueue(decimal obj)
+        public void Enqueue(float obj)
         {
             queue.Enqueue(obj);
 
@@ -33,7 +34,7 @@ namespace NGUInjector.Managers
             queue.Clear();
         }
 
-        public decimal Avg()
+        public float Avg()
         {
             try
             {
@@ -374,10 +375,17 @@ namespace NGUInjector.Managers
                 Toughness = _character.inventory.cubeToughness
             };
 
-            foreach (var item in boostSlots)
-            {
-                needed.Add(item.equipment.GetNeededBoosts());
-            }
+            //foreach (var item in boostSlots)
+            //{
+            //    var eq = item.equipment;
+
+            //    LogDebug($"{eq.id}:{item.name} (Lv {eq.level});
+            //    LogDebug($"\tAtk {eq.curAttack}/{Extensions.CalcCap(eq.capAttack, eq.level)}");
+            //    LogDebug($"\tDef {eq.curDefense}/{Extensions.CalcCap(eq.capDefense, eq.level)}");
+            //    LogDebug($"\tSpec1 {eq.spec1Cur}/{Extensions.CalcCap(eq.spec1Cap, eq.level)} | Spec2 {eq.spec2Cur}/{Extensions.CalcCap(eq.spec2Cap, eq.level)} | Spec3 {eq.spec3Cur}/{Extensions.CalcCap(eq.spec3Cap, eq.level)}");
+
+            //    needed.Add(item.equipment.GetNeededBoosts());
+            //}
 
             var current = needed.Power + needed.Toughness + needed.Special;
 
@@ -434,7 +442,7 @@ namespace NGUInjector.Managers
                     output = toughnessDiff > 0 ? $"{output} {toughnessDiff} Toughness." : output;
                     output = powerDiff > 0 ? $"{output} {powerDiff} Power." : output;
 
-                    _cubeBoostAvg.Enqueue((decimal)(toughnessDiff + powerDiff));
+                    _cubeBoostAvg.Enqueue(toughnessDiff + powerDiff);
                     output = $"{output} Average Per Minute: {_cubeBoostAvg.Avg():0}";
                     Log(output);
                     Log($"Cube Power: {cube.Power} ({_character.inventoryController.cubePowerSoftcap()} softcap). Cube Toughness: {cube.Toughness} ({_character.inventoryController.cubeToughnessSoftcap()} softcap)");
@@ -618,9 +626,9 @@ namespace NGUInjector.Managers
 
     public class BoostsNeeded
     {
-        internal decimal Power { get; set; }
-        internal decimal Toughness { get; set; }
-        internal decimal Special { get; set; }
+        internal float Power { get; set; }
+        internal float Toughness { get; set; }
+        internal float Special { get; set; }
 
         public BoostsNeeded()
         {
@@ -636,7 +644,7 @@ namespace NGUInjector.Managers
             Special += other.Special;
         }
 
-        public decimal Total()
+        public float Total()
         {
             return Power + Toughness + Special;
         }

--- a/NGUInjector/Managers/InventoryManager.cs
+++ b/NGUInjector/Managers/InventoryManager.cs
@@ -379,7 +379,7 @@ namespace NGUInjector.Managers
             //{
             //    var eq = item.equipment;
 
-            //    LogDebug($"{eq.id}:{item.name} (Lv {eq.level});
+            //    LogDebug($"{eq.id}:{item.name} (Lv {eq.level})");
             //    LogDebug($"\tAtk {eq.curAttack}/{Extensions.CalcCap(eq.capAttack, eq.level)}");
             //    LogDebug($"\tDef {eq.curDefense}/{Extensions.CalcCap(eq.capDefense, eq.level)}");
             //    LogDebug($"\tSpec1 {eq.spec1Cur}/{Extensions.CalcCap(eq.spec1Cap, eq.level)} | Spec2 {eq.spec2Cur}/{Extensions.CalcCap(eq.spec2Cap, eq.level)} | Spec3 {eq.spec3Cur}/{Extensions.CalcCap(eq.spec3Cap, eq.level)}");

--- a/NGUInjector/Managers/ZoneHelpers.cs
+++ b/NGUInjector/Managers/ZoneHelpers.cs
@@ -73,14 +73,14 @@ namespace NGUInjector.Managers
                         oldSnapshot.ShouldUseGoldLoadout = currentSnapshot.ShouldUseGoldLoadout;
                         oldSnapshot.ShouldUseTitanLoadout = currentSnapshot.ShouldUseTitanLoadout;
 
-                        //The titan is active, if it has been active for over a minute, stats may not be high enough
-                        //disable the titan to prevent sitting with suboptimal gear forever
+                        //The titan is active, if it has been active for over 5 minutes, stats are probably not be high enough to kill
+                        //Disable the titan to prevent sitting with suboptimal gear forever unless combat is currently occurring in that titan zone
                         if (oldSnapshot.SpawnSoonTimestamp.HasValue && currentSnapshot.SpawnSoonTimestamp.HasValue && (currentSnapshot.ShouldUseGoldLoadout || currentSnapshot.ShouldUseTitanLoadout))
                         {
                             //LogDebug("Waiting for kill...");
-                            if ((currentSnapshot.SpawnSoonTimestamp.Value - oldSnapshot.SpawnSoonTimestamp.Value).TotalMinutes >= 1)
+                            if ((currentSnapshot.SpawnSoonTimestamp.Value - oldSnapshot.SpawnSoonTimestamp.Value).TotalMinutes >= 5 && CombatHelpers.CurrentCombatZone != TitanZones[titanIndex])
                             {
-                                Log($"Titan {titanIndex} still available after 60 seconds");
+                                Log($"Titan {titanIndex} still available after 300 seconds");
                                 if (currentSnapshot.ShouldUseGoldLoadout)
                                 {
                                     Log($"Disabling Titan {titanIndex} as a valid gold swap target");

--- a/NGUInjector/NGUInjector.csproj
+++ b/NGUInjector/NGUInjector.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NGUInjector</RootNamespace>
     <AssemblyName>NGUInjector</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
     <TargetFrameworkProfile />
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,11 +33,12 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\steam\steamapps\common\NGU IDLE\NGUIdle_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>D:\Games\Steam\steamapps\common\NGU IDLE\NGUIdle_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -46,22 +48,22 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\2020.3.12f1\Editor\Data\Managed\UnityEngine\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.26f1\Editor\Data\Managed\UnityEngine\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\2020.3.12f1\Editor\Data\Managed\UnityEngine\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.26f1\Editor\Data\Managed\UnityEngine\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\2020.3.12f1\Editor\Data\Managed\UnityEngine\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.26f1\Editor\Data\Managed\UnityEngine\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\2020.3.12f1\Editor\Data\Managed\UnityEngine\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.26f1\Editor\Data\Managed\UnityEngine\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>C:\Program Files\Unity\Hub\Editor\2020.3.12f1\Editor\Data\Managed\UnityEngine\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>C:\Program Files\Unity\Hub\Editor\2021.3.26f1\Editor\Data\Managed\UnityEngine\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\steam\steamapps\common\NGU IDLE\NGUIdle_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>D:\Games\Steam\steamapps\common\NGU IDLE\NGUIdle_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -81,6 +83,7 @@
     <Compile Include="AllocationProfiles\CustomAllocation.cs" />
     <Compile Include="AllocationProfiles\AllocationProfile.cs" />
     <Compile Include="AllocationProfiles\BreakpointTypes\NGUBP.cs" />
+    <Compile Include="Managers\BloodMagicManager.cs" />
     <Compile Include="Managers\CardManager.cs" />
     <Compile Include="AllocationProfiles\RebirthStuff\BaseRebirth.cs" />
     <Compile Include="AllocationProfiles\RebirthStuff\BossNumRebirth.cs" />

--- a/NGUInjector/SavedSettings.cs
+++ b/NGUInjector/SavedSettings.cs
@@ -56,6 +56,9 @@ namespace NGUInjector
         [SerializeField] private int _ironPillThreshold;
         [SerializeField] private int _bloodMacGuffinAThreshold;
         [SerializeField] private int _bloodMacGuffinBThreshold;
+        [SerializeField] private bool _ironPillOnRebirth;
+        [SerializeField] private bool _bloodMacGuffinAOnRebirth;
+        [SerializeField] private bool _bloodMacGuffinBOnRebirth;
         [SerializeField] private bool _autoBuyEm;
         [SerializeField] private bool _autoBuyAdventure;
         [SerializeField] private double _bloodNumberThreshold;
@@ -226,6 +229,9 @@ namespace NGUInjector
             _ironPillThreshold = other.IronPillThreshold;
             _bloodMacGuffinAThreshold = other.BloodMacGuffinAThreshold;
             _bloodMacGuffinBThreshold = other.BloodMacGuffinBThreshold;
+            _ironPillOnRebirth = other.IronPillOnRebirth;
+            _bloodMacGuffinAOnRebirth = other.BloodMacGuffinAOnRebirth;
+            _bloodMacGuffinBOnRebirth = other.BloodMacGuffinBOnRebirth;
             _autoBuyEm = other.AutoBuyEM;
             _autoBuyAdventure = other.AutoBuyAdventure;
             _bloodNumberThreshold = other.BloodNumberThreshold;
@@ -752,6 +758,39 @@ namespace NGUInjector
             {
                 if (value == _bloodMacGuffinBThreshold) return;
                 _bloodMacGuffinBThreshold = value;
+                SaveSettings();
+            }
+        }
+
+        public bool IronPillOnRebirth
+        {
+            get => _ironPillOnRebirth;
+            set
+            {
+                if (value == _ironPillOnRebirth) return;
+                _ironPillOnRebirth = value;
+                SaveSettings();
+            }
+        }
+
+        public bool BloodMacGuffinAOnRebirth
+        {
+            get => _bloodMacGuffinAOnRebirth;
+            set
+            {
+                if (value == _bloodMacGuffinAOnRebirth) return;
+                _bloodMacGuffinAOnRebirth = value;
+                SaveSettings();
+            }
+        }
+
+        public bool BloodMacGuffinBOnRebirth
+        {
+            get => _bloodMacGuffinBOnRebirth;
+            set
+            {
+                if (value == _bloodMacGuffinBOnRebirth) return;
+                _bloodMacGuffinBOnRebirth = value;
                 SaveSettings();
             }
         }

--- a/NGUInjector/SettingsForm.Designer.cs
+++ b/NGUInjector/SettingsForm.Designer.cs
@@ -224,6 +224,9 @@
             this.balanceMayo = new System.Windows.Forms.CheckBox();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.IronPillOnRebirth = new System.Windows.Forms.CheckBox();
+            this.GuffAOnRebirth = new System.Windows.Forms.CheckBox();
+            this.GuffBOnRebirth = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.moneyPitError)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.yggErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.invPrioErrorProvider)).BeginInit();
@@ -381,6 +384,9 @@
             // 
             // tabPage2
             // 
+            this.tabPage2.Controls.Add(this.GuffBOnRebirth);
+            this.tabPage2.Controls.Add(this.GuffAOnRebirth);
+            this.tabPage2.Controls.Add(this.IronPillOnRebirth);
             this.tabPage2.Controls.Add(this.ProfileEditButton);
             this.tabPage2.Controls.Add(this.CastBloodSpells);
             this.tabPage2.Controls.Add(this.IronPillThreshold);
@@ -1801,6 +1807,27 @@
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
+            // IronPillOnRebirth
+            // 
+            resources.ApplyResources(this.IronPillOnRebirth, "IronPillOnRebirth");
+            this.IronPillOnRebirth.Name = "IronPillOnRebirth";
+            this.IronPillOnRebirth.UseVisualStyleBackColor = true;
+            this.IronPillOnRebirth.CheckedChanged += new System.EventHandler(this.IronPillOnRebirth_CheckedChanged);
+            // 
+            // GuffAOnRebirth
+            // 
+            resources.ApplyResources(this.GuffAOnRebirth, "GuffAOnRebirth");
+            this.GuffAOnRebirth.Name = "GuffAOnRebirth";
+            this.GuffAOnRebirth.UseVisualStyleBackColor = true;
+            this.GuffAOnRebirth.CheckedChanged += new System.EventHandler(this.GuffAOnRebirth_CheckedChanged);
+            // 
+            // GuffBOnRebirth
+            // 
+            resources.ApplyResources(this.GuffBOnRebirth, "GuffBOnRebirth");
+            this.GuffBOnRebirth.Name = "GuffBOnRebirth";
+            this.GuffBOnRebirth.UseVisualStyleBackColor = true;
+            this.GuffBOnRebirth.CheckedChanged += new System.EventHandler(this.GuffBOnRebirth_CheckedChanged);
+            // 
             // SettingsForm
             // 
             resources.ApplyResources(this, "$this");
@@ -2057,5 +2084,8 @@
         private System.Windows.Forms.ListBox DontCastList;
         private System.Windows.Forms.Label label29;
         private System.Windows.Forms.CheckBox TrashChunkers;
+        private System.Windows.Forms.CheckBox GuffAOnRebirth;
+        private System.Windows.Forms.CheckBox IronPillOnRebirth;
+        private System.Windows.Forms.CheckBox GuffBOnRebirth;
     }
 }

--- a/NGUInjector/SettingsForm.cs
+++ b/NGUInjector/SettingsForm.cs
@@ -301,6 +301,10 @@ namespace NGUInjector
             GuffBThreshold.Value = newSettings.BloodMacGuffinBThreshold;
             YggSwapThreshold.Value = newSettings.YggSwapThreshold;
 
+            IronPillOnRebirth.Checked = newSettings.IronPillOnRebirth;
+            GuffAOnRebirth.Checked = newSettings.BloodMacGuffinAOnRebirth;
+            GuffBOnRebirth.Checked = newSettings.BloodMacGuffinBOnRebirth;
+
             MoreBlockParry.Checked = newSettings.MoreBlockParry;
             WishSortOrder.Checked = newSettings.WishSortOrder;
             WishSortPriorities.Checked = newSettings.WishSortPriorities;
@@ -1265,7 +1269,6 @@ namespace NGUInjector
             if (_initializing) return;
             var temp = Main.Settings.TitanSwapTargets.ToArray();
             temp[(int)e.Item.Tag] = e.Item.Checked;
-            Main.Log($"{(int)e.Item.Tag} - {e.Item.Checked}");
             Main.Settings.TitanSwapTargets = temp;
         }
 
@@ -1362,6 +1365,24 @@ namespace NGUInjector
         {
             if (_initializing) return;
             Main.Settings.CastBloodSpells = CastBloodSpells.Checked;
+        }
+
+        private void IronPillOnRebirth_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.IronPillOnRebirth = IronPillOnRebirth.Checked;
+        }
+
+        private void GuffAOnRebirth_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.BloodMacGuffinAOnRebirth = GuffAOnRebirth.Checked;
+        }
+
+        private void GuffBOnRebirth_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.BloodMacGuffinBOnRebirth = GuffBOnRebirth.Checked;
         }
 
         private void QuestCombatMode_SelectedIndexChanged(object sender, EventArgs e)

--- a/NGUInjector/SettingsForm.resx
+++ b/NGUInjector/SettingsForm.resx
@@ -112,25 +112,25 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="moneyPitError.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="moneyPitError.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>665, 387</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="progressBar1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -140,7 +140,7 @@
   <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
     <value>662, 13</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -148,7 +148,7 @@
     <value>progressBar1</value>
   </data>
   <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -175,7 +175,7 @@
     <value>DisableOverlay</value>
   </data>
   <data name="&gt;&gt;DisableOverlay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DisableOverlay.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -202,7 +202,7 @@
     <value>UnloadSafety</value>
   </data>
   <data name="&gt;&gt;UnloadSafety.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UnloadSafety.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -232,7 +232,7 @@
     <value>UnloadButton</value>
   </data>
   <data name="&gt;&gt;UnloadButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UnloadButton.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -262,7 +262,7 @@
     <value>VersionLabel</value>
   </data>
   <data name="&gt;&gt;VersionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;VersionLabel.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -292,7 +292,7 @@
     <value>AutoBuyEM</value>
   </data>
   <data name="&gt;&gt;AutoBuyEM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoBuyEM.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -322,7 +322,7 @@
     <value>MasterEnable</value>
   </data>
   <data name="&gt;&gt;MasterEnable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MasterEnable.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -352,7 +352,7 @@
     <value>AutoFightBosses</value>
   </data>
   <data name="&gt;&gt;AutoFightBosses.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoFightBosses.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -382,7 +382,7 @@
     <value>AutoITOPOD</value>
   </data>
   <data name="&gt;&gt;AutoITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoITOPOD.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -409,13 +409,100 @@
     <value>tabPage1</value>
   </data>
   <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
     <value>tabControl1</value>
   </data>
   <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="GuffBOnRebirth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GuffBOnRebirth.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GuffBOnRebirth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>393, 251</value>
+  </data>
+  <data name="GuffBOnRebirth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
+  <data name="GuffBOnRebirth.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="GuffBOnRebirth.Text" xml:space="preserve">
+    <value>Cast on Rebirth</value>
+  </data>
+  <data name="&gt;&gt;GuffBOnRebirth.Name" xml:space="preserve">
+    <value>GuffBOnRebirth</value>
+  </data>
+  <data name="&gt;&gt;GuffBOnRebirth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GuffBOnRebirth.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;GuffBOnRebirth.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="GuffAOnRebirth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GuffAOnRebirth.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="GuffAOnRebirth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>393, 222</value>
+  </data>
+  <data name="GuffAOnRebirth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
+  <data name="GuffAOnRebirth.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="GuffAOnRebirth.Text" xml:space="preserve">
+    <value>Cast on Rebirth</value>
+  </data>
+  <data name="&gt;&gt;GuffAOnRebirth.Name" xml:space="preserve">
+    <value>GuffAOnRebirth</value>
+  </data>
+  <data name="&gt;&gt;GuffAOnRebirth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GuffAOnRebirth.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;GuffAOnRebirth.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="IronPillOnRebirth.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="IronPillOnRebirth.Location" type="System.Drawing.Point, System.Drawing">
+    <value>393, 192</value>
+  </data>
+  <data name="IronPillOnRebirth.Size" type="System.Drawing.Size, System.Drawing">
+    <value>99, 17</value>
+  </data>
+  <data name="IronPillOnRebirth.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="IronPillOnRebirth.Text" xml:space="preserve">
+    <value>Cast on Rebirth</value>
+  </data>
+  <data name="&gt;&gt;IronPillOnRebirth.Name" xml:space="preserve">
+    <value>IronPillOnRebirth</value>
+  </data>
+  <data name="&gt;&gt;IronPillOnRebirth.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;IronPillOnRebirth.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;IronPillOnRebirth.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="ProfileEditButton.Location" type="System.Drawing.Point, System.Drawing">
     <value>503, 13</value>
@@ -433,13 +520,13 @@
     <value>ProfileEditButton</value>
   </data>
   <data name="&gt;&gt;ProfileEditButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ProfileEditButton.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ProfileEditButton.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>3</value>
   </data>
   <data name="CastBloodSpells.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -460,13 +547,13 @@
     <value>CastBloodSpells</value>
   </data>
   <data name="&gt;&gt;CastBloodSpells.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CastBloodSpells.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;CastBloodSpells.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>4</value>
   </data>
   <data name="IronPillThreshold.Location" type="System.Drawing.Point, System.Drawing">
     <value>277, 188</value>
@@ -481,13 +568,13 @@
     <value>IronPillThreshold</value>
   </data>
   <data name="&gt;&gt;IronPillThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;IronPillThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;IronPillThreshold.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>5</value>
   </data>
   <data name="label123.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -511,13 +598,13 @@
     <value>label123</value>
   </data>
   <data name="&gt;&gt;label123.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label123.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label123.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="GuffBThreshold.Location" type="System.Drawing.Point, System.Drawing">
     <value>277, 250</value>
@@ -532,13 +619,13 @@
     <value>GuffBThreshold</value>
   </data>
   <data name="&gt;&gt;GuffBThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GuffBThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;GuffBThreshold.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>7</value>
   </data>
   <data name="label26.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -562,13 +649,13 @@
     <value>label26</value>
   </data>
   <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label26.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label26.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>8</value>
   </data>
   <data name="GuffAThreshold.Location" type="System.Drawing.Point, System.Drawing">
     <value>277, 220</value>
@@ -583,13 +670,13 @@
     <value>GuffAThreshold</value>
   </data>
   <data name="&gt;&gt;GuffAThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GuffAThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;GuffAThreshold.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>9</value>
   </data>
   <data name="label27.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -613,13 +700,13 @@
     <value>label27</value>
   </data>
   <data name="&gt;&gt;label27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label27.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label27.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>10</value>
   </data>
   <data name="UpgradeDiggers.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -643,13 +730,13 @@
     <value>UpgradeDiggers</value>
   </data>
   <data name="&gt;&gt;UpgradeDiggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UpgradeDiggers.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;UpgradeDiggers.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>11</value>
   </data>
   <data name="ManageNGUDiff.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -673,13 +760,13 @@
     <value>ManageNGUDiff</value>
   </data>
   <data name="&gt;&gt;ManageNGUDiff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageNGUDiff.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageNGUDiff.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>12</value>
   </data>
   <data name="ChangeProfileFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -700,13 +787,13 @@
     <value>ChangeProfileFile</value>
   </data>
   <data name="&gt;&gt;ChangeProfileFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ChangeProfileFile.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ChangeProfileFile.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>13</value>
   </data>
   <data name="AllocationProfileFileLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -730,13 +817,13 @@
     <value>AllocationProfileFileLabel</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFileLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFileLabel.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFileLabel.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>14</value>
   </data>
   <data name="AllocationProfileFile.Location" type="System.Drawing.Point, System.Drawing">
     <value>124, 14</value>
@@ -751,13 +838,13 @@
     <value>AllocationProfileFile</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFile.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFile.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>15</value>
   </data>
   <data name="ManageR3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -781,13 +868,13 @@
     <value>ManageR3</value>
   </data>
   <data name="&gt;&gt;ManageR3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageR3.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageR3.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>16</value>
   </data>
   <data name="BloodNumberThreshold.Location" type="System.Drawing.Point, System.Drawing">
     <value>96, 246</value>
@@ -802,13 +889,13 @@
     <value>BloodNumberThreshold</value>
   </data>
   <data name="&gt;&gt;BloodNumberThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BloodNumberThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;BloodNumberThreshold.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>17</value>
   </data>
   <data name="label18.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -832,13 +919,13 @@
     <value>label18</value>
   </data>
   <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label18.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label18.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>18</value>
   </data>
   <data name="SaveSpellCapButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -859,13 +946,13 @@
     <value>SaveSpellCapButton</value>
   </data>
   <data name="&gt;&gt;SaveSpellCapButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SaveSpellCapButton.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;SaveSpellCapButton.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>19</value>
   </data>
   <data name="AutoSpellSwap.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -889,13 +976,13 @@
     <value>AutoSpellSwap</value>
   </data>
   <data name="&gt;&gt;AutoSpellSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoSpellSwap.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;AutoSpellSwap.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>20</value>
   </data>
   <data name="label17.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -913,13 +1000,13 @@
     <value>label17</value>
   </data>
   <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label17.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label17.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>21</value>
   </data>
   <data name="CounterfeitCap.Location" type="System.Drawing.Point, System.Drawing">
     <value>96, 220</value>
@@ -934,13 +1021,13 @@
     <value>CounterfeitCap</value>
   </data>
   <data name="&gt;&gt;CounterfeitCap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CounterfeitCap.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;CounterfeitCap.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>22</value>
   </data>
   <data name="label16.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -964,13 +1051,13 @@
     <value>label16</value>
   </data>
   <data name="&gt;&gt;label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label16.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>23</value>
   </data>
   <data name="SpaghettiCap.Location" type="System.Drawing.Point, System.Drawing">
     <value>96, 190</value>
@@ -985,13 +1072,13 @@
     <value>SpaghettiCap</value>
   </data>
   <data name="&gt;&gt;SpaghettiCap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SpaghettiCap.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;SpaghettiCap.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>24</value>
   </data>
   <data name="label15.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1015,13 +1102,13 @@
     <value>label15</value>
   </data>
   <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label15.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label15.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>25</value>
   </data>
   <data name="label14.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1045,13 +1132,13 @@
     <value>label14</value>
   </data>
   <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label14.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>26</value>
   </data>
   <data name="AutoRebirth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1075,13 +1162,13 @@
     <value>AutoRebirth</value>
   </data>
   <data name="&gt;&gt;AutoRebirth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoRebirth.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;AutoRebirth.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>27</value>
   </data>
   <data name="ManageWandoos.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1105,13 +1192,13 @@
     <value>ManageWandoos</value>
   </data>
   <data name="&gt;&gt;ManageWandoos.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageWandoos.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageWandoos.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>28</value>
   </data>
   <data name="ManageDiggers.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1135,13 +1222,13 @@
     <value>ManageDiggers</value>
   </data>
   <data name="&gt;&gt;ManageDiggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageDiggers.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageDiggers.ZOrder" xml:space="preserve">
-    <value>26</value>
+    <value>29</value>
   </data>
   <data name="ManageGear.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1165,13 +1252,13 @@
     <value>ManageGear</value>
   </data>
   <data name="&gt;&gt;ManageGear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageGear.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageGear.ZOrder" xml:space="preserve">
-    <value>27</value>
+    <value>30</value>
   </data>
   <data name="ManageMagic.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1195,13 +1282,13 @@
     <value>ManageMagic</value>
   </data>
   <data name="&gt;&gt;ManageMagic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageMagic.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageMagic.ZOrder" xml:space="preserve">
-    <value>28</value>
+    <value>31</value>
   </data>
   <data name="ManageEnergy.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1225,13 +1312,13 @@
     <value>ManageEnergy</value>
   </data>
   <data name="&gt;&gt;ManageEnergy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageEnergy.Parent" xml:space="preserve">
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;ManageEnergy.ZOrder" xml:space="preserve">
-    <value>29</value>
+    <value>32</value>
   </data>
   <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -1252,7 +1339,7 @@
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -1273,7 +1360,7 @@
     <value>YggSwapThreshold</value>
   </data>
   <data name="&gt;&gt;YggSwapThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;YggSwapThreshold.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1300,7 +1387,7 @@
     <value>HarvestSafety</value>
   </data>
   <data name="&gt;&gt;HarvestSafety.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HarvestSafety.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1330,7 +1417,7 @@
     <value>HarvestAllButton</value>
   </data>
   <data name="&gt;&gt;HarvestAllButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HarvestAllButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1360,7 +1447,7 @@
     <value>ActivateFruits</value>
   </data>
   <data name="&gt;&gt;ActivateFruits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ActivateFruits.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1381,7 +1468,7 @@
     <value>4, 55</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>56, 16</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1393,7 +1480,7 @@
     <value>label3</value>
   </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label3.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1423,7 +1510,7 @@
     <value>yggRemoveButton</value>
   </data>
   <data name="&gt;&gt;yggRemoveButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggRemoveButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1444,7 +1531,7 @@
     <value>yggLoadoutItem</value>
   </data>
   <data name="&gt;&gt;yggLoadoutItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggLoadoutItem.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1474,7 +1561,7 @@
     <value>yggItemLabel</value>
   </data>
   <data name="&gt;&gt;yggItemLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggItemLabel.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1501,7 +1588,7 @@
     <value>yggAddButton</value>
   </data>
   <data name="&gt;&gt;yggAddButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggAddButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1528,7 +1615,7 @@
     <value>yggdrasilLoadoutBox</value>
   </data>
   <data name="&gt;&gt;yggdrasilLoadoutBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggdrasilLoadoutBox.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1558,7 +1645,7 @@
     <value>YggdrasilSwap</value>
   </data>
   <data name="&gt;&gt;YggdrasilSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;YggdrasilSwap.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1588,7 +1675,7 @@
     <value>ManageYggdrasil</value>
   </data>
   <data name="&gt;&gt;ManageYggdrasil.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageYggdrasil.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1615,7 +1702,7 @@
     <value>tabPage3</value>
   </data>
   <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -1639,7 +1726,7 @@
     <value>BoostAvgReset</value>
   </data>
   <data name="&gt;&gt;BoostAvgReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BoostAvgReset.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1660,7 +1747,7 @@
     <value>CubePriority</value>
   </data>
   <data name="&gt;&gt;CubePriority.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CubePriority.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1690,7 +1777,7 @@
     <value>label20</value>
   </data>
   <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label20.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1720,7 +1807,7 @@
     <value>prioDownButton</value>
   </data>
   <data name="&gt;&gt;prioDownButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;prioDownButton.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1750,7 +1837,7 @@
     <value>prioUpButton</value>
   </data>
   <data name="&gt;&gt;prioUpButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;prioUpButton.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1771,7 +1858,7 @@
     <value>299, 85</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 16</value>
+    <value>108, 16</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -1783,7 +1870,7 @@
     <value>label5</value>
   </data>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label5.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1813,7 +1900,7 @@
     <value>blacklistRemove</value>
   </data>
   <data name="&gt;&gt;blacklistRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistRemove.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1834,7 +1921,7 @@
     <value>blacklistAddItem</value>
   </data>
   <data name="&gt;&gt;blacklistAddItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistAddItem.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1864,7 +1951,7 @@
     <value>blacklistLabel</value>
   </data>
   <data name="&gt;&gt;blacklistLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistLabel.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1891,7 +1978,7 @@
     <value>blacklistAdd</value>
   </data>
   <data name="&gt;&gt;blacklistAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1918,7 +2005,7 @@
     <value>blacklistBox</value>
   </data>
   <data name="&gt;&gt;blacklistBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistBox.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1939,7 +2026,7 @@
     <value>6, 85</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 16</value>
+    <value>93, 16</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -1951,7 +2038,7 @@
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1981,7 +2068,7 @@
     <value>priorityBoostRemove</value>
   </data>
   <data name="&gt;&gt;priorityBoostRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostRemove.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2002,7 +2089,7 @@
     <value>priorityBoostItemAdd</value>
   </data>
   <data name="&gt;&gt;priorityBoostItemAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostItemAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2032,7 +2119,7 @@
     <value>priorityBoostLabel</value>
   </data>
   <data name="&gt;&gt;priorityBoostLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostLabel.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2059,7 +2146,7 @@
     <value>priorityBoostAdd</value>
   </data>
   <data name="&gt;&gt;priorityBoostAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2086,7 +2173,7 @@
     <value>priorityBoostBox</value>
   </data>
   <data name="&gt;&gt;priorityBoostBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostBox.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2116,7 +2203,7 @@
     <value>ManageInventory</value>
   </data>
   <data name="&gt;&gt;ManageInventory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageInventory.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2146,7 +2233,7 @@
     <value>ManageBoostConvert</value>
   </data>
   <data name="&gt;&gt;ManageBoostConvert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageBoostConvert.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2173,7 +2260,7 @@
     <value>tabPage4</value>
   </data>
   <data name="&gt;&gt;tabPage4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage4.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -2194,7 +2281,7 @@
     <value>362, 36</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 16</value>
+    <value>118, 16</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -2206,7 +2293,7 @@
     <value>label9</value>
   </data>
   <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label9.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2233,7 +2320,7 @@
     <value>TitanSwapTargets</value>
   </data>
   <data name="&gt;&gt;TitanSwapTargets.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TitanSwapTargets.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2254,7 +2341,7 @@
     <value>6, 36</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>56, 16</value>
   </data>
   <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2266,7 +2353,7 @@
     <value>label8</value>
   </data>
   <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label8.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2296,7 +2383,7 @@
     <value>titanRemove</value>
   </data>
   <data name="&gt;&gt;titanRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanRemove.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2317,7 +2404,7 @@
     <value>titanAddItem</value>
   </data>
   <data name="&gt;&gt;titanAddItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanAddItem.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2347,7 +2434,7 @@
     <value>titanLabel</value>
   </data>
   <data name="&gt;&gt;titanLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanLabel.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2374,7 +2461,7 @@
     <value>titanAdd</value>
   </data>
   <data name="&gt;&gt;titanAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanAdd.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2401,7 +2488,7 @@
     <value>titanLoadout</value>
   </data>
   <data name="&gt;&gt;titanLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanLoadout.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2431,7 +2518,7 @@
     <value>SwapTitanLoadout</value>
   </data>
   <data name="&gt;&gt;SwapTitanLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SwapTitanLoadout.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2458,7 +2545,7 @@
     <value>tabPage5</value>
   </data>
   <data name="&gt;&gt;tabPage5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage5.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -2482,7 +2569,7 @@
     <value>label32</value>
   </data>
   <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label32.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2512,7 +2599,7 @@
     <value>BlacklistAddEnemyButton</value>
   </data>
   <data name="&gt;&gt;BlacklistAddEnemyButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistAddEnemyButton.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2542,7 +2629,7 @@
     <value>label31</value>
   </data>
   <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label31.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2563,7 +2650,7 @@
     <value>EnemyBlacklistNames</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistNames.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistNames.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2593,7 +2680,7 @@
     <value>BlacklistRemoveEnemyButton</value>
   </data>
   <data name="&gt;&gt;BlacklistRemoveEnemyButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistRemoveEnemyButton.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2614,7 +2701,7 @@
     <value>EnemyBlacklistZone</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistZone.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2635,7 +2722,7 @@
     <value>BlacklistedBosses</value>
   </data>
   <data name="&gt;&gt;BlacklistedBosses.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistedBosses.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2662,7 +2749,7 @@
     <value>MoreBlockParry</value>
   </data>
   <data name="&gt;&gt;MoreBlockParry.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoreBlockParry.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2692,7 +2779,7 @@
     <value>ITOPODBeastMode</value>
   </data>
   <data name="&gt;&gt;ITOPODBeastMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODBeastMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2722,7 +2809,7 @@
     <value>ITOPODRecoverHP</value>
   </data>
   <data name="&gt;&gt;ITOPODRecoverHP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODRecoverHP.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2752,7 +2839,7 @@
     <value>ITOPODFastCombat</value>
   </data>
   <data name="&gt;&gt;ITOPODFastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODFastCombat.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2782,7 +2869,7 @@
     <value>ITOPODPrecastBuffs</value>
   </data>
   <data name="&gt;&gt;ITOPODPrecastBuffs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODPrecastBuffs.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2812,7 +2899,7 @@
     <value>label24</value>
   </data>
   <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label24.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2839,7 +2926,7 @@
     <value>ITOPODCombatMode</value>
   </data>
   <data name="&gt;&gt;ITOPODCombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODCombatMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2863,7 +2950,7 @@
     <value>label22</value>
   </data>
   <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label22.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2893,7 +2980,7 @@
     <value>label23</value>
   </data>
   <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label23.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2923,7 +3010,7 @@
     <value>TargetITOPOD</value>
   </data>
   <data name="&gt;&gt;TargetITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetITOPOD.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2953,7 +3040,7 @@
     <value>OptimizeITOPOD</value>
   </data>
   <data name="&gt;&gt;OptimizeITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OptimizeITOPOD.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2983,7 +3070,7 @@
     <value>BeastMode</value>
   </data>
   <data name="&gt;&gt;BeastMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BeastMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3013,7 +3100,7 @@
     <value>AllowFallthrough</value>
   </data>
   <data name="&gt;&gt;AllowFallthrough.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllowFallthrough.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3043,7 +3130,7 @@
     <value>RecoverHealth</value>
   </data>
   <data name="&gt;&gt;RecoverHealth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RecoverHealth.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3073,7 +3160,7 @@
     <value>FastCombat</value>
   </data>
   <data name="&gt;&gt;FastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;FastCombat.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3103,7 +3190,7 @@
     <value>PrecastBuffs</value>
   </data>
   <data name="&gt;&gt;PrecastBuffs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;PrecastBuffs.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3133,7 +3220,7 @@
     <value>label6</value>
   </data>
   <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label6.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3160,7 +3247,7 @@
     <value>CombatTargetZone</value>
   </data>
   <data name="&gt;&gt;CombatTargetZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatTargetZone.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3190,7 +3277,7 @@
     <value>label4</value>
   </data>
   <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label4.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3217,7 +3304,7 @@
     <value>CombatMode</value>
   </data>
   <data name="&gt;&gt;CombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3247,7 +3334,7 @@
     <value>BossesOnly</value>
   </data>
   <data name="&gt;&gt;BossesOnly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BossesOnly.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3277,7 +3364,7 @@
     <value>CombatActive</value>
   </data>
   <data name="&gt;&gt;CombatActive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatActive.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3304,7 +3391,7 @@
     <value>tabPage6</value>
   </data>
   <data name="&gt;&gt;tabPage6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage6.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -3334,7 +3421,7 @@
     <value>CBlockMode</value>
   </data>
   <data name="&gt;&gt;CBlockMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CBlockMode.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3361,7 +3448,7 @@
     <value>ResetTitanStatus</value>
   </data>
   <data name="&gt;&gt;ResetTitanStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResetTitanStatus.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3382,7 +3469,7 @@
     <value>350, 70</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 16</value>
+    <value>118, 16</value>
   </data>
   <data name="label21.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -3394,7 +3481,7 @@
     <value>label21</value>
   </data>
   <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label21.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3421,7 +3508,7 @@
     <value>TitanGoldTargets</value>
   </data>
   <data name="&gt;&gt;TitanGoldTargets.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TitanGoldTargets.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3448,7 +3535,7 @@
     <value>SaveResnipeButton</value>
   </data>
   <data name="&gt;&gt;SaveResnipeButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SaveResnipeButton.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3469,7 +3556,7 @@
     <value>ResnipeInput</value>
   </data>
   <data name="&gt;&gt;ResnipeInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResnipeInput.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3499,7 +3586,7 @@
     <value>label10</value>
   </data>
   <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label10.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3529,7 +3616,7 @@
     <value>ManageGoldLoadouts</value>
   </data>
   <data name="&gt;&gt;ManageGoldLoadouts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageGoldLoadouts.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3559,7 +3646,7 @@
     <value>UseGoldLoadout</value>
   </data>
   <data name="&gt;&gt;UseGoldLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UseGoldLoadout.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3580,7 +3667,7 @@
     <value>4, 70</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>56, 16</value>
   </data>
   <data name="label11.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -3592,7 +3679,7 @@
     <value>label11</value>
   </data>
   <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label11.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3622,7 +3709,7 @@
     <value>GoldLoadoutRemove</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutRemove.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3643,7 +3730,7 @@
     <value>GoldItemBox</value>
   </data>
   <data name="&gt;&gt;GoldItemBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldItemBox.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3673,7 +3760,7 @@
     <value>GoldItemLabel</value>
   </data>
   <data name="&gt;&gt;GoldItemLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldItemLabel.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3700,7 +3787,7 @@
     <value>GoldLoadoutAdd</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutAdd.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3727,7 +3814,7 @@
     <value>GoldLoadout</value>
   </data>
   <data name="&gt;&gt;GoldLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadout.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3754,7 +3841,7 @@
     <value>tabPage7</value>
   </data>
   <data name="&gt;&gt;tabPage7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage7.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -3784,7 +3871,7 @@
     <value>ButterMinors</value>
   </data>
   <data name="&gt;&gt;ButterMinors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ButterMinors.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3814,7 +3901,7 @@
     <value>ButterMajors</value>
   </data>
   <data name="&gt;&gt;ButterMajors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ButterMajors.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3844,7 +3931,7 @@
     <value>ManualMinor</value>
   </data>
   <data name="&gt;&gt;ManualMinor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManualMinor.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3874,7 +3961,7 @@
     <value>QuestFastCombat</value>
   </data>
   <data name="&gt;&gt;QuestFastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;QuestFastCombat.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3904,7 +3991,7 @@
     <value>AbandonMinors</value>
   </data>
   <data name="&gt;&gt;AbandonMinors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AbandonMinors.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3925,7 +4012,7 @@
     <value>AbandonMinorThreshold</value>
   </data>
   <data name="&gt;&gt;AbandonMinorThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AbandonMinorThreshold.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3955,7 +4042,7 @@
     <value>label13</value>
   </data>
   <data name="&gt;&gt;label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label13.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -3985,7 +4072,7 @@
     <value>label12</value>
   </data>
   <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label12.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -4012,7 +4099,7 @@
     <value>QuestCombatMode</value>
   </data>
   <data name="&gt;&gt;QuestCombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;QuestCombatMode.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -4042,7 +4129,7 @@
     <value>AllowMajor</value>
   </data>
   <data name="&gt;&gt;AllowMajor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllowMajor.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -4072,7 +4159,7 @@
     <value>ManageQuests</value>
   </data>
   <data name="&gt;&gt;ManageQuests.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageQuests.Parent" xml:space="preserve">
     <value>tabPage8</value>
@@ -4099,7 +4186,7 @@
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;tabPage8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage8.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4126,7 +4213,7 @@
     <value>WishSortOrder</value>
   </data>
   <data name="&gt;&gt;WishSortOrder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishSortOrder.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4153,7 +4240,7 @@
     <value>WishSortPriorities</value>
   </data>
   <data name="&gt;&gt;WishSortPriorities.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishSortPriorities.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4183,7 +4270,7 @@
     <value>WishDownButton</value>
   </data>
   <data name="&gt;&gt;WishDownButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishDownButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4213,7 +4300,7 @@
     <value>WishUpButton</value>
   </data>
   <data name="&gt;&gt;WishUpButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishUpButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4243,7 +4330,7 @@
     <value>RemoveWishButton</value>
   </data>
   <data name="&gt;&gt;RemoveWishButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RemoveWishButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4264,7 +4351,7 @@
     <value>6, 35</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 16</value>
+    <value>96, 16</value>
   </data>
   <data name="label19.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -4276,7 +4363,7 @@
     <value>label19</value>
   </data>
   <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label19.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4297,7 +4384,7 @@
     <value>WishAddInput</value>
   </data>
   <data name="&gt;&gt;WishAddInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishAddInput.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4327,7 +4414,7 @@
     <value>AddWishLabel</value>
   </data>
   <data name="&gt;&gt;AddWishLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AddWishLabel.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4354,7 +4441,7 @@
     <value>AddWishButton</value>
   </data>
   <data name="&gt;&gt;AddWishButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AddWishButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4381,7 +4468,7 @@
     <value>WishPriority</value>
   </data>
   <data name="&gt;&gt;WishPriority.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishPriority.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4408,7 +4495,7 @@
     <value>tabPage9</value>
   </data>
   <data name="&gt;&gt;tabPage9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage9.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4429,7 +4516,7 @@
     <value>6, 68</value>
   </data>
   <data name="label25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>56, 16</value>
   </data>
   <data name="label25.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -4441,7 +4528,7 @@
     <value>label25</value>
   </data>
   <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label25.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4471,7 +4558,7 @@
     <value>MoneyPitRemove</value>
   </data>
   <data name="&gt;&gt;MoneyPitRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitRemove.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4492,7 +4579,7 @@
     <value>MoneyPitInput</value>
   </data>
   <data name="&gt;&gt;MoneyPitInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitInput.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4522,7 +4609,7 @@
     <value>MoneyPitLabel</value>
   </data>
   <data name="&gt;&gt;MoneyPitLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitLabel.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4549,7 +4636,7 @@
     <value>MoneyPitAdd</value>
   </data>
   <data name="&gt;&gt;MoneyPitAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitAdd.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4576,7 +4663,7 @@
     <value>MoneyPitLoadout</value>
   </data>
   <data name="&gt;&gt;MoneyPitLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitLoadout.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4603,7 +4690,7 @@
     <value>MoneyPitThresholdSave</value>
   </data>
   <data name="&gt;&gt;MoneyPitThresholdSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitThresholdSave.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4624,7 +4711,7 @@
     <value>MoneyPitThreshold</value>
   </data>
   <data name="&gt;&gt;MoneyPitThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitThreshold.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4654,7 +4741,7 @@
     <value>label7</value>
   </data>
   <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label7.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4684,7 +4771,7 @@
     <value>AutoMoneyPit</value>
   </data>
   <data name="&gt;&gt;AutoMoneyPit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoMoneyPit.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4711,7 +4798,7 @@
     <value>AutoDailySpin</value>
   </data>
   <data name="&gt;&gt;AutoDailySpin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoDailySpin.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4738,7 +4825,7 @@
     <value>tabPage10</value>
   </data>
   <data name="&gt;&gt;tabPage10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage10.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4765,7 +4852,7 @@
     <value>TrashChunkers</value>
   </data>
   <data name="&gt;&gt;TrashChunkers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TrashChunkers.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4789,7 +4876,7 @@
     <value>DontCastRemove</value>
   </data>
   <data name="&gt;&gt;DontCastRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DontCastRemove.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4813,7 +4900,7 @@
     <value>DontCastAdd</value>
   </data>
   <data name="&gt;&gt;DontCastAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DontCastAdd.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4834,7 +4921,7 @@
     <value>DontCastSelection</value>
   </data>
   <data name="&gt;&gt;DontCastSelection.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DontCastSelection.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4855,7 +4942,7 @@
     <value>DontCastList</value>
   </data>
   <data name="&gt;&gt;DontCastList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DontCastList.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4882,7 +4969,7 @@
     <value>label29</value>
   </data>
   <data name="&gt;&gt;label29.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label29.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4909,7 +4996,7 @@
     <value>label28</value>
   </data>
   <data name="&gt;&gt;label28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label28.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4930,7 +5017,7 @@
     <value>TrashTier</value>
   </data>
   <data name="&gt;&gt;TrashTier.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TrashTier.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4957,7 +5044,7 @@
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -4984,7 +5071,7 @@
     <value>TrashAdventureCards</value>
   </data>
   <data name="&gt;&gt;TrashAdventureCards.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TrashAdventureCards.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5011,7 +5098,7 @@
     <value>AutoCastCards</value>
   </data>
   <data name="&gt;&gt;AutoCastCards.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoCastCards.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5038,7 +5125,7 @@
     <value>label34</value>
   </data>
   <data name="&gt;&gt;label34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label34.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5068,7 +5155,7 @@
     <value>label33</value>
   </data>
   <data name="&gt;&gt;label33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label33.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5089,7 +5176,7 @@
     <value>TrashQuality</value>
   </data>
   <data name="&gt;&gt;TrashQuality.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TrashQuality.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5116,7 +5203,7 @@
     <value>TrashCards</value>
   </data>
   <data name="&gt;&gt;TrashCards.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TrashCards.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5143,7 +5230,7 @@
     <value>balanceMayo</value>
   </data>
   <data name="&gt;&gt;balanceMayo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;balanceMayo.Parent" xml:space="preserve">
     <value>tabPage11</value>
@@ -5170,7 +5257,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;tabPage11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage11.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -5191,7 +5278,7 @@
     <value>tabControl1</value>
   </data>
   <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -5221,7 +5308,7 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -5236,87 +5323,87 @@
     <value>moneyPitError</value>
   </data>
   <data name="&gt;&gt;moneyPitError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggErrorProvider.Name" xml:space="preserve">
     <value>yggErrorProvider</value>
   </data>
   <data name="&gt;&gt;yggErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;invPrioErrorProvider.Name" xml:space="preserve">
     <value>invPrioErrorProvider</value>
   </data>
   <data name="&gt;&gt;invPrioErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;invBlacklistErrProvider.Name" xml:space="preserve">
     <value>invBlacklistErrProvider</value>
   </data>
   <data name="&gt;&gt;invBlacklistErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanErrProvider.Name" xml:space="preserve">
     <value>titanErrProvider</value>
   </data>
   <data name="&gt;&gt;titanErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;goldErrorProvider.Name" xml:space="preserve">
     <value>goldErrorProvider</value>
   </data>
   <data name="&gt;&gt;goldErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;numberErrProvider.Name" xml:space="preserve">
     <value>numberErrProvider</value>
   </data>
   <data name="&gt;&gt;numberErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;wishErrorProvider.Name" xml:space="preserve">
     <value>wishErrorProvider</value>
   </data>
   <data name="&gt;&gt;wishErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;columnHeader2.Name" xml:space="preserve">
     <value>columnHeader2</value>
   </data>
   <data name="&gt;&gt;columnHeader2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;columnHeader1.Name" xml:space="preserve">
     <value>columnHeader1</value>
   </data>
   <data name="&gt;&gt;columnHeader1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SettingsForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <metadata name="yggErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="yggErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>146, 17</value>
   </metadata>
-  <metadata name="invPrioErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="invPrioErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>290, 17</value>
   </metadata>
-  <metadata name="invBlacklistErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="invBlacklistErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>451, 17</value>
   </metadata>
-  <metadata name="titanErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="titanErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>622, 17</value>
   </metadata>
-  <metadata name="goldErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="goldErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>758, 17</value>
   </metadata>
-  <metadata name="numberErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="numberErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>906, 17</value>
   </metadata>
-  <metadata name="wishErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="wishErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1060, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Fix for Walderp combat bug
Update to heal logic to be more aggressive on titan fights
Increase disable titan logic to 5 minutes and never disable a titan if combat is set to that titan's zone
Implement reset boost average button
Cast configured blood magic spells on rebirth
Fix for digger logic, if the breakpoint fails to set diggers due to insufficent GPM, continue to try until diggers are set (most useful for challenges when TM wont be active for a while)