### PR TITLE
- Implementation of Cooking tab

### DIFF
--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -47,7 +47,7 @@ namespace NGUInjector
         private float _timeLeft = 10.0f;
         internal static SettingsForm settingsForm;
         internal static WishManager WishManager;
-        internal const string Version = "3.8.1";
+        internal const string Version = "3.8.2";
         private static int _furthestZone;
 
         private static string _dir;
@@ -321,6 +321,7 @@ namespace NGUInjector
                         ManageMayo = false,
                         TrashCards = false,
                         TrashAdventureCards = false,
+                        TrashProtectedCards = false,
                         AutoCastCards = false,
                         CardsTrashQuality = 0,
                         CardSortOrder = new string[0],
@@ -333,7 +334,10 @@ namespace NGUInjector
                         MergeBlacklist = new int[] { },
                         ManageConsumables = false,
                         AutoBuyConsumables = false,
-                        ConsumeIfAlreadyRunning = false
+                        ConsumeIfAlreadyRunning = false,
+                        ManageCooking = false,
+                        ManageCookingLoadouts = false,
+                        CookingLoadout = new int[] { }
                     };
 
                     Settings.MassUpdate(temp);
@@ -1276,31 +1280,24 @@ namespace NGUInjector
 
             if (questZone > 0)
             {
-                if ((Settings.AdventureTargetTitans && ZoneHelpers.AnyTitansSpawningSoon()) || (ZoneHelpers.ZoneIsTitan(Settings.SnipeZone) && ZoneHelpers.TitanSpawningSoon(Array.IndexOf(ZoneHelpers.TitanZones, Settings.SnipeZone))))
+                if (Settings.QuestCombatMode == 0)
                 {
-                    // DONT quest IF we have a titan spawning soon
+                    _combManager.ManualZone(questZone, false, false, false, Settings.QuestFastCombat, Settings.QuestBeastMode, Settings.QuestSmartBeastMode);
                 }
-                else if (!Settings.CombatEnabled || Settings.AdventureTargetITOPOD || !CombatManager.IsZoneUnlocked(Settings.SnipeZone))
+                else
                 {
-                    // DO quest if there is no titan spawning and Combat is disabled, the ITOPOD override is set, or the target zone is locked
-                    if (Settings.QuestCombatMode == 0)
-                    {
-                        _combManager.ManualZone(questZone, false, false, false, Settings.QuestFastCombat, Settings.QuestBeastMode, Settings.QuestSmartBeastMode);
-                    }
-                    else
-                    {
-                        _combManager.IdleZone(questZone, false, false, Settings.QuestBeastMode);
-                    }
+                    _combManager.IdleZone(questZone, false, false, Settings.QuestBeastMode);
+                }
 
-                    CombatHelpers.IsCurrentlyQuesting = true;
-                    return;
-                }
+                CombatHelpers.IsCurrentlyQuesting = true;
+                return;
             }
 
             if (!Settings.CombatEnabled)
                 return;
 
             var tempZone = Settings.AdventureTargetITOPOD ? 1000 : Settings.SnipeZone;
+
             if (tempZone < 1000)
             {
                 if (!CombatManager.IsZoneUnlocked(Settings.SnipeZone))

--- a/NGUInjector/Managers/LoadoutManager.cs
+++ b/NGUInjector/Managers/LoadoutManager.cs
@@ -122,7 +122,7 @@ namespace NGUInjector.Managers
                     Settings.DoGoldSwap = false;
                     //LogDebug("Gold Gear swap");
                 }
-                else
+                else if(ZoneHelpers.ShouldRunTitanLoadout())
                 {
                     Log("Equipping Titan Loadout");
                     ChangeGear(Settings.TitanLoadout);

--- a/NGUInjector/SavedSettings.cs
+++ b/NGUInjector/SavedSettings.cs
@@ -116,6 +116,7 @@ namespace NGUInjector
         [SerializeField] private int _cardsTrashQuality;
         [SerializeField] private bool _autoCastCards;
         [SerializeField] private bool _trashAdventureCards;
+        [SerializeField] private bool _trashProtectedCards;
         [SerializeField] private string[] _cardSortOrder;
         [SerializeField] private bool _cardSortEnabled;
         [SerializeField] private int _trashCardCost;
@@ -1432,6 +1433,17 @@ namespace NGUInjector
             {
                 if (value == _trashAdventureCards) return;
                 _trashAdventureCards = value;
+                SaveSettings();
+            }
+        }
+
+        public bool TrashProtectedCards
+        {
+            get => _trashProtectedCards;
+            set
+            {
+                if (value == _trashProtectedCards) return;
+                _trashProtectedCards = value;
                 SaveSettings();
             }
         }

--- a/NGUInjector/SettingsForm.Designer.cs
+++ b/NGUInjector/SettingsForm.Designer.cs
@@ -128,6 +128,7 @@
             this.ManageInventory = new System.Windows.Forms.CheckBox();
             this.ManageBoostConvert = new System.Windows.Forms.CheckBox();
             this.tabPage5 = new System.Windows.Forms.TabPage();
+            this.LocateWalderp = new System.Windows.Forms.Button();
             this.UseTitanCombat = new System.Windows.Forms.CheckBox();
             this.TitanSmartBeastMode = new System.Windows.Forms.CheckBox();
             this.TitanMoreBlockParry = new System.Windows.Forms.CheckBox();
@@ -248,6 +249,7 @@
             this.AutoMoneyPit = new System.Windows.Forms.CheckBox();
             this.AutoDailySpin = new System.Windows.Forms.CheckBox();
             this.tabPage11 = new System.Windows.Forms.TabPage();
+            this.TrashProtectedCards = new System.Windows.Forms.CheckBox();
             this.CardSortOptions = new System.Windows.Forms.ComboBox();
             this.label37 = new System.Windows.Forms.Label();
             this.CardSortRemove = new System.Windows.Forms.Button();
@@ -274,11 +276,20 @@
             this.TrashQuality = new System.Windows.Forms.ComboBox();
             this.TrashCards = new System.Windows.Forms.CheckBox();
             this.balanceMayo = new System.Windows.Forms.CheckBox();
+            this.tabPage12 = new System.Windows.Forms.TabPage();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.questErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.wishBlacklistErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
-            this.LocateWalderp = new System.Windows.Forms.Button();
+            this.label42 = new System.Windows.Forms.Label();
+            this.cookingRemoveButton = new System.Windows.Forms.Button();
+            this.CookingLoadoutItem = new System.Windows.Forms.NumericUpDown();
+            this.cookingItemLabel = new System.Windows.Forms.Label();
+            this.cookingAddButton = new System.Windows.Forms.Button();
+            this.cookingLoadoutBox = new System.Windows.Forms.ListBox();
+            this.ManageCookingLoadout = new System.Windows.Forms.CheckBox();
+            this.ManageCooking = new System.Windows.Forms.CheckBox();
+            this.cookingErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.moneyPitThresholdError)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.yggErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.invPrioErrorProvider)).BeginInit();
@@ -317,9 +328,12 @@
             this.tabPage10.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MoneyPitInput)).BeginInit();
             this.tabPage11.SuspendLayout();
+            this.tabPage12.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.questErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.wishBlacklistErrorProvider)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CookingLoadoutItem)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cookingErrorProvider)).BeginInit();
             this.SuspendLayout();
             // 
             // moneyPitThresholdError
@@ -371,6 +385,7 @@
             this.tabControl1.Controls.Add(this.tabPage9);
             this.tabControl1.Controls.Add(this.tabPage10);
             this.tabControl1.Controls.Add(this.tabPage11);
+            this.tabControl1.Controls.Add(this.tabPage12);
             resources.ApplyResources(this.tabControl1, "tabControl1");
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
@@ -1110,6 +1125,13 @@
             resources.ApplyResources(this.tabPage5, "tabPage5");
             this.tabPage5.Name = "tabPage5";
             this.tabPage5.UseVisualStyleBackColor = true;
+            // 
+            // LocateWalderp
+            // 
+            resources.ApplyResources(this.LocateWalderp, "LocateWalderp");
+            this.LocateWalderp.Name = "LocateWalderp";
+            this.LocateWalderp.UseVisualStyleBackColor = true;
+            this.LocateWalderp.Click += new System.EventHandler(this.LocateWalderp_Click);
             // 
             // UseTitanCombat
             // 
@@ -2074,6 +2096,7 @@
             // 
             // tabPage11
             // 
+            this.tabPage11.Controls.Add(this.TrashProtectedCards);
             this.tabPage11.Controls.Add(this.CardSortOptions);
             this.tabPage11.Controls.Add(this.label37);
             this.tabPage11.Controls.Add(this.CardSortRemove);
@@ -2103,6 +2126,13 @@
             resources.ApplyResources(this.tabPage11, "tabPage11");
             this.tabPage11.Name = "tabPage11";
             this.tabPage11.UseVisualStyleBackColor = true;
+            // 
+            // TrashProtectedCards
+            // 
+            resources.ApplyResources(this.TrashProtectedCards, "TrashProtectedCards");
+            this.TrashProtectedCards.Name = "TrashProtectedCards";
+            this.TrashProtectedCards.UseVisualStyleBackColor = true;
+            this.TrashProtectedCards.CheckedChanged += new System.EventHandler(this.TrashProtectedCards_CheckedChanged);
             // 
             // CardSortOptions
             // 
@@ -2269,6 +2299,20 @@
             this.balanceMayo.UseVisualStyleBackColor = true;
             this.balanceMayo.CheckedChanged += new System.EventHandler(this.manageMayo_CheckedChanged);
             // 
+            // tabPage12
+            // 
+            this.tabPage12.Controls.Add(this.label42);
+            this.tabPage12.Controls.Add(this.cookingRemoveButton);
+            this.tabPage12.Controls.Add(this.CookingLoadoutItem);
+            this.tabPage12.Controls.Add(this.cookingItemLabel);
+            this.tabPage12.Controls.Add(this.cookingAddButton);
+            this.tabPage12.Controls.Add(this.cookingLoadoutBox);
+            this.tabPage12.Controls.Add(this.ManageCookingLoadout);
+            this.tabPage12.Controls.Add(this.ManageCooking);
+            resources.ApplyResources(this.tabPage12, "tabPage12");
+            this.tabPage12.Name = "tabPage12";
+            this.tabPage12.UseVisualStyleBackColor = true;
+            // 
             // progressBar1
             // 
             resources.ApplyResources(this.progressBar1, "progressBar1");
@@ -2289,12 +2333,72 @@
             // 
             this.wishBlacklistErrorProvider.ContainerControl = this;
             // 
-            // LocateWalderp
+            // label42
             // 
-            resources.ApplyResources(this.LocateWalderp, "LocateWalderp");
-            this.LocateWalderp.Name = "LocateWalderp";
-            this.LocateWalderp.UseVisualStyleBackColor = true;
-            this.LocateWalderp.Click += new System.EventHandler(this.LocateWalderp_Click);
+            resources.ApplyResources(this.label42, "label42");
+            this.label42.Name = "label42";
+            // 
+            // cookingRemoveButton
+            // 
+            resources.ApplyResources(this.cookingRemoveButton, "cookingRemoveButton");
+            this.cookingRemoveButton.Name = "cookingRemoveButton";
+            this.cookingRemoveButton.UseVisualStyleBackColor = true;
+            this.cookingRemoveButton.Click += new System.EventHandler(this.cookingRemoveButton_Click);
+            // 
+            // CookingLoadoutItem
+            // 
+            resources.ApplyResources(this.CookingLoadoutItem, "CookingLoadoutItem");
+            this.CookingLoadoutItem.Maximum = new decimal(new int[] {
+            999999999,
+            0,
+            0,
+            0});
+            this.CookingLoadoutItem.Name = "CookingLoadoutItem";
+            this.CookingLoadoutItem.Value = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.CookingLoadoutItem.KeyDown += new System.Windows.Forms.KeyEventHandler(this.CookingLoadoutItem_KeyDown);
+            // 
+            // cookingItemLabel
+            // 
+            resources.ApplyResources(this.cookingItemLabel, "cookingItemLabel");
+            this.cookingItemLabel.Name = "cookingItemLabel";
+            // 
+            // cookingAddButton
+            // 
+            resources.ApplyResources(this.cookingAddButton, "cookingAddButton");
+            this.cookingAddButton.Name = "cookingAddButton";
+            this.cookingAddButton.UseVisualStyleBackColor = true;
+            this.cookingAddButton.Click += new System.EventHandler(this.cookingAddButton_Click);
+            // 
+            // cookingLoadoutBox
+            // 
+            this.cookingLoadoutBox.FormattingEnabled = true;
+            this.cookingLoadoutBox.Items.AddRange(new object[] {
+            resources.GetString("cookingLoadoutBox.Items"),
+            resources.GetString("cookingLoadoutBox.Items1")});
+            resources.ApplyResources(this.cookingLoadoutBox, "cookingLoadoutBox");
+            this.cookingLoadoutBox.Name = "cookingLoadoutBox";
+            // 
+            // ManageCookingLoadout
+            // 
+            resources.ApplyResources(this.ManageCookingLoadout, "ManageCookingLoadout");
+            this.ManageCookingLoadout.Name = "ManageCookingLoadout";
+            this.ManageCookingLoadout.UseVisualStyleBackColor = true;
+            this.ManageCookingLoadout.CheckedChanged += new System.EventHandler(this.ManageCookingLoadout_CheckedChanged);
+            // 
+            // ManageCooking
+            // 
+            resources.ApplyResources(this.ManageCooking, "ManageCooking");
+            this.ManageCooking.Name = "ManageCooking";
+            this.ManageCooking.UseVisualStyleBackColor = true;
+            this.ManageCooking.CheckedChanged += new System.EventHandler(this.ManageCooking_CheckedChanged);
+            // 
+            // cookingErrorProvider
+            // 
+            this.cookingErrorProvider.ContainerControl = this;
             // 
             // SettingsForm
             // 
@@ -2355,9 +2459,13 @@
             ((System.ComponentModel.ISupportInitialize)(this.MoneyPitInput)).EndInit();
             this.tabPage11.ResumeLayout(false);
             this.tabPage11.PerformLayout();
+            this.tabPage12.ResumeLayout(false);
+            this.tabPage12.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.questErrorProvider)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.wishBlacklistErrorProvider)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CookingLoadoutItem)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cookingErrorProvider)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -2612,5 +2720,16 @@
         private System.Windows.Forms.Button CardSortAdd;
         private System.Windows.Forms.Label label41;
         private System.Windows.Forms.Button LocateWalderp;
+        private System.Windows.Forms.CheckBox TrashProtectedCards;
+        private System.Windows.Forms.TabPage tabPage12;
+        private System.Windows.Forms.Label label42;
+        private System.Windows.Forms.Button cookingRemoveButton;
+        private System.Windows.Forms.NumericUpDown CookingLoadoutItem;
+        private System.Windows.Forms.Label cookingItemLabel;
+        private System.Windows.Forms.Button cookingAddButton;
+        private System.Windows.Forms.ListBox cookingLoadoutBox;
+        private System.Windows.Forms.CheckBox ManageCookingLoadout;
+        private System.Windows.Forms.CheckBox ManageCooking;
+        private System.Windows.Forms.ErrorProvider cookingErrorProvider;
     }
 }

--- a/NGUInjector/SettingsForm.cs
+++ b/NGUInjector/SettingsForm.cs
@@ -100,6 +100,7 @@ namespace NGUInjector
         private ItemControlGroup _wishControls;
         private ItemControlGroup _wishBlacklistControls;
         private ItemControlGroup _pitControls;
+        private ItemControlGroup _cookingControls;
 
         //TODO: Implement missing manual features:
         //      NEW Tab: Cooking (ManageCooking flag, ManageCookingLoadout flag Cooking gear loadout)
@@ -209,6 +210,7 @@ namespace NGUInjector
                 WishAddInput.TextChanged += WishAddInput_TextChanged;
                 WishBlacklistAddInput.TextChanged += WishBlacklistAddInput_TextChanged;
                 MoneyPitInput.TextChanged += MoneyPitInput_TextChanged;
+                CookingLoadoutItem.TextChanged += CookingLoadoutBox_TextChanged;
 
                 _yggControls = new ItemControlGroup(yggdrasilLoadoutBox, yggLoadoutItem, yggErrorProvider, yggItemLabel, () => Main.Settings.YggdrasilLoadout, (settings) => Main.Settings.YggdrasilLoadout = settings);
                 _priorityControls = new ItemControlGroup(priorityBoostBox, priorityBoostItemAdd, invPrioErrorProvider, priorityBoostLabel, () => Main.Settings.PriorityBoosts, (settings) => Main.Settings.PriorityBoosts = settings);
@@ -219,6 +221,7 @@ namespace NGUInjector
                 _wishControls = new ItemControlGroup(WishPriority, WishAddInput, wishErrorProvider, AddWishLabel, () => Main.Settings.WishPriorities, (settings) => Main.Settings.WishPriorities = settings, 0, Consts.MAX_WISH_ID, false, (id) => Main.Character.wishesController.properties[id].wishName);
                 _wishBlacklistControls = new ItemControlGroup(WishBlacklist, WishBlacklistAddInput, wishBlacklistErrorProvider, AddWishBlacklistLabel, () => Main.Settings.WishBlacklist, (settings) => Main.Settings.WishBlacklist = settings, 0, Consts.MAX_WISH_ID, false, (id) => Main.Character.wishesController.properties[id].wishName);
                 _pitControls = new ItemControlGroup(MoneyPitLoadout, MoneyPitInput, moneyPitErrorProvider, MoneyPitLabel, () => Main.Settings.MoneyPitLoadout, (settings) => Main.Settings.MoneyPitLoadout = settings);
+                _cookingControls = new ItemControlGroup(cookingLoadoutBox, CookingLoadoutItem, cookingErrorProvider, cookingItemLabel, () => Main.Settings.CookingLoadout, (settings) => Main.Settings.CookingLoadout = settings);
 
                 TryItemBoxTextChanged(_yggControls, out _);
                 TryItemBoxTextChanged(_priorityControls, out _);
@@ -229,6 +232,7 @@ namespace NGUInjector
                 TryItemBoxTextChanged(_wishControls, out _);
                 TryItemBoxTextChanged(_wishBlacklistControls, out _);
                 TryItemBoxTextChanged(_pitControls, out _);
+                TryItemBoxTextChanged(_cookingControls, out _);
 
                 UseTitanCombat_CheckedChanged(this, null);
 
@@ -406,9 +410,13 @@ namespace NGUInjector
             TrashQuality.SelectedIndex = newSettings.CardsTrashQuality;
             TrashTier.SelectedIndex = newSettings.TrashCardCost;
             TrashAdventureCards.Checked = newSettings.TrashAdventureCards;
+            TrashProtectedCards.Checked = newSettings.TrashProtectedCards;
             AutoCastCards.Checked = newSettings.AutoCastCards;
             TrashChunkers.Checked = newSettings.TrashChunkers;
             SortCards.Checked = newSettings.CardSortEnabled;
+
+            ManageCooking.Checked = newSettings.ManageCooking;
+            ManageCookingLoadout.Checked = newSettings.ManageCookingLoadouts;
 
             if (newSettings.DontCastCardType != null)
             {
@@ -561,6 +569,19 @@ namespace NGUInjector
             else
             {
                 BlacklistedBosses.Items.Clear();
+            }
+
+            temp = newSettings.CookingLoadout.ToDictionary(x => x, x => Main.Character.itemInfo.itemName[x]);
+            if (temp.Count > 0)
+            {
+                cookingLoadoutBox.DataSource = null;
+                cookingLoadoutBox.DataSource = new BindingSource(temp, null);
+                cookingLoadoutBox.ValueMember = "Key";
+                cookingLoadoutBox.DisplayMember = "Value";
+            }
+            else
+            {
+                cookingLoadoutBox.Items.Clear();
             }
 
             Refresh();
@@ -1647,6 +1668,12 @@ namespace NGUInjector
             Main.Settings.TrashAdventureCards = TrashAdventureCards.Checked;
         }
 
+        private void TrashProtectedCards_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.TrashProtectedCards = TrashProtectedCards.Checked;
+        }
+
         private void trashCardCost_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (_initializing) return;
@@ -1820,5 +1847,40 @@ namespace NGUInjector
                 Main.Character.menuSwapper.swapMenu(Main.Character.waldoUnlocker.currentMenu);
             }
         }
+
+        private void ManageCooking_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.ManageCooking = ManageCooking.Checked;
+        }
+
+        private void ManageCookingLoadout_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.ManageCookingLoadouts = ManageCookingLoadout.Checked;
+        }
+
+        private void CookingLoadoutBox_TextChanged(object sender, EventArgs e)
+        {
+            TryItemBoxTextChanged(_cookingControls, out _);
+        }
+
+        private void CookingLoadoutItem_KeyDown(object sender, KeyEventArgs e)
+        {
+            ItemBoxKeyDown(e, _cookingControls);
+        }
+
+        private void cookingAddButton_Click(object sender, EventArgs e)
+        {
+            ItemListAdd(_cookingControls);
+        }
+
+        private void cookingRemoveButton_Click(object sender, EventArgs e)
+        {
+
+            ItemListRemove(_cookingControls);
+        }
+
+
     }
 }

--- a/NGUInjector/SettingsForm.resx
+++ b/NGUInjector/SettingsForm.resx
@@ -131,7 +131,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>665, 387</value>
+    <value>664, 387</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="progressBar1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
@@ -514,7 +514,7 @@
     <value>0</value>
   </data>
   <data name="tabPage1.Text" xml:space="preserve">
-    <value>General Settings</value>
+    <value>General</value>
   </data>
   <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
     <value>tabPage1</value>
@@ -2875,13 +2875,13 @@
     <value>390, 27</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 16</value>
+    <value>111, 16</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
   </data>
   <data name="label9.Text" xml:space="preserve">
-    <value>Titans to Swap For</value>
+    <value>Titans to Manage</value>
   </data>
   <data name="&gt;&gt;label9.Name" xml:space="preserve">
     <value>label9</value>
@@ -3100,13 +3100,13 @@
     <value>7, 7</value>
   </data>
   <data name="SwapTitanLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
+    <value>97, 17</value>
   </data>
   <data name="SwapTitanLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
   <data name="SwapTitanLoadout.Text" xml:space="preserve">
-    <value>Swap Loadout for Titans</value>
+    <value>Manage Titans</value>
   </data>
   <data name="&gt;&gt;SwapTitanLoadout.Name" xml:space="preserve">
     <value>SwapTitanLoadout</value>
@@ -3208,7 +3208,7 @@
     <value>True</value>
   </data>
   <data name="TargetTitans.Location" type="System.Drawing.Point, System.Drawing">
-    <value>431, 86</value>
+    <value>511, 88</value>
   </data>
   <data name="TargetTitans.Size" type="System.Drawing.Size, System.Drawing">
     <value>55, 17</value>
@@ -3673,7 +3673,7 @@
     <value>NoControl</value>
   </data>
   <data name="TargetITOPOD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 86</value>
+    <value>437, 88</value>
   </data>
   <data name="TargetITOPOD.Size" type="System.Drawing.Size, System.Drawing">
     <value>67, 17</value>
@@ -3763,7 +3763,7 @@
     <value>NoControl</value>
   </data>
   <data name="AllowFallthrough.Location" type="System.Drawing.Point, System.Drawing">
-    <value>245, 85</value>
+    <value>325, 87</value>
   </data>
   <data name="AllowFallthrough.Size" type="System.Drawing.Size, System.Drawing">
     <value>106, 17</value>
@@ -3997,7 +3997,7 @@
     <value>NoControl</value>
   </data>
   <data name="BossesOnly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 7</value>
+    <value>235, 87</value>
   </data>
   <data name="BossesOnly.Size" type="System.Drawing.Size, System.Drawing">
     <value>84, 17</value>
@@ -4147,13 +4147,13 @@
     <value>350, 70</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 16</value>
+    <value>128, 16</value>
   </data>
   <data name="label21.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
   </data>
   <data name="label21.Text" xml:space="preserve">
-    <value>Titans to Swap For</value>
+    <value>Titans to Gold Snipe</value>
   </data>
   <data name="&gt;&gt;label21.Name" xml:space="preserve">
     <value>label21</value>
@@ -4657,7 +4657,7 @@
     <value>NoControl</value>
   </data>
   <data name="questRemoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>225, 180</value>
+    <value>260, 180</value>
   </data>
   <data name="questRemoveButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 23</value>
@@ -4684,7 +4684,7 @@
     <value>10, 274</value>
   </data>
   <data name="QuestLoadoutItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 20</value>
+    <value>244, 20</value>
   </data>
   <data name="QuestLoadoutItem.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -4735,7 +4735,7 @@
     <value>NoControl</value>
   </data>
   <data name="questAddButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>225, 274</value>
+    <value>260, 274</value>
   </data>
   <data name="questAddButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 20</value>
@@ -4768,7 +4768,7 @@
     <value>9, 107</value>
   </data>
   <data name="questLoadoutBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 160</value>
+    <value>245, 160</value>
   </data>
   <data name="questLoadoutBox.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -5937,6 +5937,36 @@
   <data name="&gt;&gt;tabPage10.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="TrashProtectedCards.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="TrashProtectedCards.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="TrashProtectedCards.Location" type="System.Drawing.Point, System.Drawing">
+    <value>482, 7</value>
+  </data>
+  <data name="TrashProtectedCards.Size" type="System.Drawing.Size, System.Drawing">
+    <value>132, 17</value>
+  </data>
+  <data name="TrashProtectedCards.TabIndex" type="System.Int32, mscorlib">
+    <value>46</value>
+  </data>
+  <data name="TrashProtectedCards.Text" xml:space="preserve">
+    <value>Trash Protected Cards</value>
+  </data>
+  <data name="&gt;&gt;TrashProtectedCards.Name" xml:space="preserve">
+    <value>TrashProtectedCards</value>
+  </data>
+  <data name="&gt;&gt;TrashProtectedCards.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TrashProtectedCards.Parent" xml:space="preserve">
+    <value>tabPage11</value>
+  </data>
+  <data name="&gt;&gt;TrashProtectedCards.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="CardSortOptions.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 297</value>
   </data>
@@ -5956,7 +5986,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortOptions.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="label37.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -5986,7 +6016,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label37.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="CardSortRemove.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6013,7 +6043,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortRemove.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="CardSortAdd.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -6040,7 +6070,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortAdd.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="label41.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6073,7 +6103,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label41.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="CardSortList.Items" xml:space="preserve">
     <value>test</value>
@@ -6100,7 +6130,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortList.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="CardSortDown.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6130,7 +6160,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortDown.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="CardSortUp.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6160,7 +6190,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;CardSortUp.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="label40.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6172,7 +6202,7 @@
     <value>NoControl</value>
   </data>
   <data name="label40.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 99</value>
+    <value>6, 99</value>
   </data>
   <data name="label40.Size" type="System.Drawing.Size, System.Drawing">
     <value>68, 16</value>
@@ -6193,13 +6223,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label40.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="SortCards.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="SortCards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 79</value>
+    <value>7, 79</value>
   </data>
   <data name="SortCards.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 17</value>
@@ -6220,13 +6250,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;SortCards.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="TrashChunkers.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="TrashChunkers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>456, 100</value>
+    <value>455, 100</value>
   </data>
   <data name="TrashChunkers.Size" type="System.Drawing.Size, System.Drawing">
     <value>101, 17</value>
@@ -6247,7 +6277,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;TrashChunkers.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="DontCastRemove.Location" type="System.Drawing.Point, System.Drawing">
     <value>562, 186</value>
@@ -6271,7 +6301,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;DontCastRemove.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="DontCastAdd.Location" type="System.Drawing.Point, System.Drawing">
     <value>562, 295</value>
@@ -6295,7 +6325,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;DontCastAdd.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="DontCastSelection.Location" type="System.Drawing.Point, System.Drawing">
     <value>341, 297</value>
@@ -6316,7 +6346,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;DontCastSelection.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="DontCastList.Location" type="System.Drawing.Point, System.Drawing">
     <value>341, 118</value>
@@ -6337,7 +6367,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;DontCastList.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="label29.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6364,13 +6394,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label29.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="label28.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
-    <value>562, 65</value>
+    <value>562, 58</value>
   </data>
   <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
     <value>79, 13</value>
@@ -6391,10 +6421,10 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label28.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="TrashTier.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 62</value>
+    <value>419, 55</value>
   </data>
   <data name="TrashTier.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
@@ -6412,13 +6442,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;TrashTier.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>338, 65</value>
+    <value>338, 58</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 13</value>
@@ -6439,13 +6469,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="TrashAdventureCards.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="TrashAdventureCards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>455, 7</value>
+    <value>341, 7</value>
   </data>
   <data name="TrashAdventureCards.Size" type="System.Drawing.Size, System.Drawing">
     <value>135, 17</value>
@@ -6466,13 +6496,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;TrashAdventureCards.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="AutoCastCards.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="AutoCastCards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>107, 7</value>
+    <value>7, 30</value>
   </data>
   <data name="AutoCastCards.Size" type="System.Drawing.Size, System.Drawing">
     <value>102, 17</value>
@@ -6493,13 +6523,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;AutoCastCards.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="label34.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label34.Location" type="System.Drawing.Point, System.Drawing">
-    <value>563, 36</value>
+    <value>562, 31</value>
   </data>
   <data name="label34.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 13</value>
@@ -6520,7 +6550,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label34.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="label33.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6529,7 +6559,7 @@
     <value>NoControl</value>
   </data>
   <data name="label33.Location" type="System.Drawing.Point, System.Drawing">
-    <value>338, 36</value>
+    <value>338, 31</value>
   </data>
   <data name="label33.Size" type="System.Drawing.Size, System.Drawing">
     <value>76, 13</value>
@@ -6550,10 +6580,10 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;label33.ZOrder" xml:space="preserve">
-    <value>22</value>
+    <value>23</value>
   </data>
   <data name="TrashQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 33</value>
+    <value>419, 28</value>
   </data>
   <data name="TrashQuality.Size" type="System.Drawing.Size, System.Drawing">
     <value>137, 21</value>
@@ -6571,13 +6601,13 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;TrashQuality.ZOrder" xml:space="preserve">
-    <value>23</value>
+    <value>24</value>
   </data>
   <data name="TrashCards.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="TrashCards.Location" type="System.Drawing.Point, System.Drawing">
-    <value>341, 7</value>
+    <value>107, 7</value>
   </data>
   <data name="TrashCards.Size" type="System.Drawing.Size, System.Drawing">
     <value>108, 17</value>
@@ -6598,7 +6628,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;TrashCards.ZOrder" xml:space="preserve">
-    <value>24</value>
+    <value>25</value>
   </data>
   <data name="balanceMayo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -6625,7 +6655,7 @@
     <value>tabPage11</value>
   </data>
   <data name="&gt;&gt;balanceMayo.ZOrder" xml:space="preserve">
-    <value>25</value>
+    <value>26</value>
   </data>
   <data name="tabPage11.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -6653,6 +6683,258 @@
   </data>
   <data name="&gt;&gt;tabPage11.ZOrder" xml:space="preserve">
     <value>10</value>
+  </data>
+  <data name="label42.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label42.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="label42.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label42.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 88</value>
+  </data>
+  <data name="label42.Size" type="System.Drawing.Size, System.Drawing">
+    <value>56, 16</value>
+  </data>
+  <data name="label42.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
+  </data>
+  <data name="label42.Text" xml:space="preserve">
+    <value>Loadout</value>
+  </data>
+  <data name="&gt;&gt;label42.Name" xml:space="preserve">
+    <value>label42</value>
+  </data>
+  <data name="&gt;&gt;label42.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label42.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;label42.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cookingRemoveButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cookingRemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cookingRemoveButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>268, 170</value>
+  </data>
+  <data name="cookingRemoveButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 23</value>
+  </data>
+  <data name="cookingRemoveButton.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="cookingRemoveButton.Text" xml:space="preserve">
+    <value>Remove Item</value>
+  </data>
+  <data name="&gt;&gt;cookingRemoveButton.Name" xml:space="preserve">
+    <value>cookingRemoveButton</value>
+  </data>
+  <data name="&gt;&gt;cookingRemoveButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cookingRemoveButton.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;cookingRemoveButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CookingLoadoutItem.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 274</value>
+  </data>
+  <data name="CookingLoadoutItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>251, 20</value>
+  </data>
+  <data name="CookingLoadoutItem.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="&gt;&gt;CookingLoadoutItem.Name" xml:space="preserve">
+    <value>CookingLoadoutItem</value>
+  </data>
+  <data name="&gt;&gt;CookingLoadoutItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CookingLoadoutItem.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;CookingLoadoutItem.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cookingItemLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cookingItemLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cookingItemLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 297</value>
+  </data>
+  <data name="cookingItemLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>14, 13</value>
+  </data>
+  <data name="cookingItemLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="cookingItemLabel.Text" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="&gt;&gt;cookingItemLabel.Name" xml:space="preserve">
+    <value>cookingItemLabel</value>
+  </data>
+  <data name="&gt;&gt;cookingItemLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cookingItemLabel.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;cookingItemLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cookingAddButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cookingAddButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>268, 274</value>
+  </data>
+  <data name="cookingAddButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 20</value>
+  </data>
+  <data name="cookingAddButton.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="cookingAddButton.Text" xml:space="preserve">
+    <value>Add Item</value>
+  </data>
+  <data name="&gt;&gt;cookingAddButton.Name" xml:space="preserve">
+    <value>cookingAddButton</value>
+  </data>
+  <data name="&gt;&gt;cookingAddButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cookingAddButton.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;cookingAddButton.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="cookingLoadoutBox.Items" xml:space="preserve">
+    <value>test</value>
+  </data>
+  <data name="cookingLoadoutBox.Items1" xml:space="preserve">
+    <value>test2</value>
+  </data>
+  <data name="cookingLoadoutBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 107</value>
+  </data>
+  <data name="cookingLoadoutBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>252, 160</value>
+  </data>
+  <data name="cookingLoadoutBox.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="&gt;&gt;cookingLoadoutBox.Name" xml:space="preserve">
+    <value>cookingLoadoutBox</value>
+  </data>
+  <data name="&gt;&gt;cookingLoadoutBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cookingLoadoutBox.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;cookingLoadoutBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="ManageCookingLoadout.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ManageCookingLoadout.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ManageCookingLoadout.Location" type="System.Drawing.Point, System.Drawing">
+    <value>120, 6</value>
+  </data>
+  <data name="ManageCookingLoadout.Size" type="System.Drawing.Size, System.Drawing">
+    <value>152, 17</value>
+  </data>
+  <data name="ManageCookingLoadout.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="ManageCookingLoadout.Text" xml:space="preserve">
+    <value>Swap Loadout for Cooking</value>
+  </data>
+  <data name="&gt;&gt;ManageCookingLoadout.Name" xml:space="preserve">
+    <value>ManageCookingLoadout</value>
+  </data>
+  <data name="&gt;&gt;ManageCookingLoadout.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ManageCookingLoadout.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;ManageCookingLoadout.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ManageCooking.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ManageCooking.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 6</value>
+  </data>
+  <data name="ManageCooking.Size" type="System.Drawing.Size, System.Drawing">
+    <value>108, 17</value>
+  </data>
+  <data name="ManageCooking.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="ManageCooking.Text" xml:space="preserve">
+    <value>Manage Cooking</value>
+  </data>
+  <data name="&gt;&gt;ManageCooking.Name" xml:space="preserve">
+    <value>ManageCooking</value>
+  </data>
+  <data name="&gt;&gt;ManageCooking.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ManageCooking.Parent" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;ManageCooking.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="tabPage12.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tabPage12.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tabPage12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 334</value>
+  </data>
+  <data name="tabPage12.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="tabPage12.Text" xml:space="preserve">
+    <value>Cooking</value>
+  </data>
+  <data name="&gt;&gt;tabPage12.Name" xml:space="preserve">
+    <value>tabPage12</value>
+  </data>
+  <data name="&gt;&gt;tabPage12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage12.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tabPage12.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
   <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 22</value>
@@ -6685,7 +6967,7 @@
     <value>0, 0</value>
   </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>665, 387</value>
+    <value>664, 387</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6786,6 +7068,12 @@
   <data name="&gt;&gt;wishBlacklistErrorProvider.Type" xml:space="preserve">
     <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;cookingErrorProvider.Name" xml:space="preserve">
+    <value>cookingErrorProvider</value>
+  </data>
+  <data name="&gt;&gt;cookingErrorProvider.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SettingsForm</value>
   </data>
@@ -6821,5 +7109,8 @@
   </metadata>
   <metadata name="wishBlacklistErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>881, 51</value>
+  </metadata>
+  <metadata name="cookingErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1276, 33</value>
   </metadata>
 </root>

--- a/readme.MD
+++ b/readme.MD
@@ -39,13 +39,11 @@ Saving settings.json, zoneOverrides.json, or any profile will automatically relo
 
 # Settings.json Configurations
 
-With the latest fork, many changes have been added that aren't found in the GUI.
+Settings in the GUI can be managed directly in the underlying settings file if desired. This can be helpful when pasting in loadouts from the Gear Optimizer. To access these settings, open the **settings.json** file in your AppData NGUInjector folder mentioned above.
 
-To access these settings, open the **settings.json** (in your AppData NGUInjector folder, mentioned above) and scroll down to find the following configuration options:
+There should be only one setting not found in the GUI and *must* be managed directly:
 
-- **\_manageCooking** - Set this to true to have the injector optimize your cooking efficiency
-- **\_manageCookingLoadouts** - Set this to true to have the injector swap to a Cooking loadout when eating meals
-- **\_cookingLoadout** - Assign your cooking loadout here. Follow similar pattern as other loadout fields (example: [448, 447, 444, 170, 263, 169, 128, 243, 136, 91, 446, 137, 256, 265, 266, 267, 268, 269])
+- **_debugAllocation** - Will enable debug logging to a separate file of various allocation decisions made by the injector
 
 # Log Parsing
 
@@ -60,7 +58,7 @@ This is what it looks like once you set it up:
 
 An in game menu can be opened using the F1 button.
 
-![General Settings](https://i.imgur.com/636AxqC.png)
+![General](https://i.imgur.com/5k0KmJm.png)
 
 - **Master Switch** - If turned off, will disable all automation
 - **Disable Overlay** - If switched on, will disable the in-game overlay.
@@ -77,7 +75,7 @@ An in game menu can be opened using the F1 button.
 
 - **Unload** - Allows you to unload the injector from the game. Check the box next to the unload button and then hit unload
 
-![Allocation Settings](https://i.imgur.com/vPnH6UW.png)
+![Allocation](https://i.imgur.com/FvoQLZF.png)
 
 - **Allocation Profile** - Allows you to quickly switch allocation profiles. Any profiles stored in the profiles folder will be listed here. Press "Change profile" to load the profile selected in the dropdown. Press "Edit" to open the selected profile in a text editor. Press "Open Profile Folder" to open the folder containing all profiles.
 
@@ -108,7 +106,7 @@ An in game menu can be opened using the F1 button.
 - **Guff B** - Number of +levels to cast Guff B at
 - **Cast on Rebirth Options** - If selected will use all available blood on the selected options if cooldown and threshold requirements are met. Priority is Guff B > Guff A > Iron Pill. Will use remaining blood on Number if any remains.
 
-![Yggdrasil](https://i.imgur.com/vyLJKFI.png)
+![Yggdrasil](https://i.imgur.com/EksfVj0.png)
 
 - **Manage Yggdrasil** - Automatically harvest fruits.
 - **Activate Fruits** - Reactivate fruits you haven't bought the exp perk for
@@ -117,7 +115,7 @@ An in game menu can be opened using the F1 button.
 - **Loadout** - Edit the loadout used for harvest yggdrasil. Add items using the box in the bottom.
 - **Harvest All Now** - Allows you to do a Yggdrasil swap and immediately harvest all fruits. Check the box next to the button to enable it. Good for manual rebirths
 
-![Inventory](https://i.imgur.com/Zd7zD9C.png)
+![Inventory](https://i.imgur.com/4smaL33.png)
 
 - **Manage Inventory** - When enabled, the following features will be enabled
   - **Auto Boost Merging** - If a boost is locked, boosts will automatically be merged until the boost hits 100.
@@ -137,12 +135,12 @@ An in game menu can be opened using the F1 button.
 - **Blacklisted Items** - Edit the items you wish to never be boosted. Add items using the box in the bottom. Supersedes Priority list if the same item is in both lists.
 - **Reset Boost Average** - Resets the running average of cube/item boosting
 
-![Titans](https://i.imgur.com/D4ehZ9b.png)
+![Titans](https://i.imgur.com/a7CNoqN.png)
 
-- **Swap Loadout for Titans** - Equip the gear in TitanLoadout right before any titan marked for swapping
+- **Manage Titans** - Turns on combat and gear swapping for titans.
 - **Use Titan Combat Settings** - If enabled will override the default combat settings in the Adventure tab.
-- **Loadout** - The gear to equip when autokilling titans.
-- **Titans to Swap For** - Mark titans you wish to swap gear for
+- **Loadout** - The gear to equip when autokilling or fighting titans.
+- **Titans to Manage** - Mark titans you wish to fight and swap gear for
 - **Combat Mode** - If set to manual, will execute a custom combat routine. If set to idle, will just idle the zone. *WALDERP, THE GODMOTHER, and THE EXILE will ALWAYS use manual combat regardless of this setting*
 - **Precast Buffs** - If enabled, will cast charge and parry in safe zone before each titan attempt and wait for the cooldowns to recharge. Ignored during Idle combat mode.
 - **Recover HP** - If enabled, will recover HP in safe zone between titan kills attempts.
@@ -152,10 +150,9 @@ An in game menu can be opened using the F1 button.
 - **Block/Parry with Buffs** - If checked, combat will use block/parry along with offensive/defensive/ultimate buffs. Ignored during Idle combat mode.
 - **Locate Walderp** - If Walderp is hiding, will take you to the menu he's currently in.
 
-![Adventure](https://i.imgur.com/fRx8Y8v.png)
+![Adventure](https://i.imgur.com/91ri7DG.png)
 
 - **Combat Enabled** - Turns on auto combat to go to target zone and kill stuff.
-- **Bosses Only** - If enabled, will only fight bosses when doing combat. Good for zone sniping.
 
 - **Precast Buffs** - If enabled, will cast charge and parry in safe zone before each combat and wait for the cooldowns to recharge. Ignored during Idle combat mode.
 - **Recover HP** - If enabled, will recover HP in safe zone between kills
@@ -164,10 +161,12 @@ An in game menu can be opened using the F1 button.
 - **Smart Beast Mode** - Will enable beast mode if Defensive or Ultimate Buff is active, Piercing or Ultimate Attacks can be used AND beast mode can be turned off again before that buff expires. Will deselect Beast Mode option if selected. Ignored during Idle combat mode or if Fast Combat is enabled.
 - **Block/Parry with Buffs** - If checked, combat will use block/parry along with offensive/defensive/ultimate buffs. Ignored during Idle combat mode.
 - **Combat Mode** - If set to manual, will execute a custom combat routine. If set to idle, will just idle the zone. *WALDERP and THE GODMOTHER will ALWAYS use manual combat regardless of this setting*
-- **Target Zone** - The target zone to snipe/do combat in. ITOPOD is at the bottom of the list.
+
+- **Target Zone** - The target zone to snipe/do combat in. ITOPOD is at the bottom of the list. If the target zone is a titan zone, will idle in ITOPOD until the Titan is about to spawn. Also, will use combat settings/gear defined in the Titans tab even if the Manage Titans flag is disabled.
+- **Bosses Only** - If enabled, will only fight bosses when doing combat. Good for zone sniping.
 - **Allow Fallthrough** - If set to true, combat will use the highest unlocked zone you have until the target zone is unlocked.
 - **ITOPOD** - Equivalent to setting target zone to ITOPOD, just a quicker option
-- **Titans** - Will move you to each Titan Zone enabled in the Titans and Gold tabs when the Titan is about to spawn. Higher level titans will be fought first. Uses the non-ITOPOD combat settings.
+- **Titans** - Will move you to each Titan enabled in the Titans and/or Gold tabs when the Titan is about to spawn. Higher level titans will be fought first, Gold loadouts take priority. Uses the non-ITOPOD combat settings unless Titan Combat Settings are enabled in the Titans tab.
 
 - **ITOPOD Settings** - Settings below this apply only to ITOPOD combat
 - **Combat Mode** - If set to manual, will execute a custom combat routine. If set to idle, will just idle the zone.
@@ -180,23 +179,25 @@ An in game menu can be opened using the F1 button.
 
 - **Blacklisted Enemies** - Allows you to blacklist enemies when searching for enemies in a zone.
 
-![Gold](https://i.imgur.com/WkQhXXR.png)
+![Gold](https://i.imgur.com/CAZvwq9.png)
 
 - **Enable Gold Management** - If turned off, will disable all gold swap logic
 - **Do Gold Snipe** - If checked, will immediately equip gold loadout gear and perform a boss snipe in the best calculated zone based on the zone stats and gold loadout power/toughness.
 - **Resnipe Time** - Set this value to re-enable gold snipe at a certain time during your rebirth. Best set to after AT is completed in order to get a higher zone.
 - **CBlock Mode** - If checked, will automatically gold snipe every new zone that is unlocked. Useful for challenge blocks where zones sporadically become available.
 - **Loadout** - Items to use when swapping for gold loadout.
-- **Titans to Swap For** - Check the box next to titans you want to swap to gold loadouts for. Leave all boxes unchecked in order to never use gold loadouts for titans. If a titan is green, gold snipe has already been completed for this titan.
+- **Titans to Gold Snipe** - Check the box next to titans you want to swap to gold loadouts for. Leave all boxes unchecked in order to never use gold loadouts for titans. If a titan is green, gold snipe has already been completed for this titan.
 - **Reset Titan Status** - Immediately mark all titan gold swaps as incomplete
 
-![Quests](https://i.imgur.com/GXqG2It.png)
+![Quests](https://i.imgur.com/URjSuL1.png)
 
 - **Auto Quest** - If enabled, quests will automatically be turned in. Behavior varies based on the Allow Major Quests option
 - **Allow Major Quests**
   - If this option is enabled, when major quests are available they will be accepted and automation will manually farm the items from the appropriate zone
   - If this option is disabled, major quests will not be accepted.
   - When no major quests are available, minor quests will be accepted and idled.
+  - Manual questing will pause while titan combat is occurring
+  - Manual questing will NOT occur if a zone is currently being sniped in the Adventure tab.
 - **Use Butter on Majors** - If enabled will attempt to butter major quests
 - **Manual Minors** - If enabled will manual minor quests as well as majors
 - **Use Butter on Minors** - If enabled will attempt to butter minor quests
@@ -209,21 +210,21 @@ An in game menu can be opened using the F1 button.
 - **Beast Mode** - Whether to use beast mode or not while in combat. Will deselect Smart Beast Mode option if selected.
 - **Smart Beast Mode** - Will enable beast mode if Defensive or Ultimate Buff is active, Piercing or Ultimate Attacks can be used AND beast mode can be turned off again before that buff expires. Will deselect Beast Mode option if selected. Ignored during Idle combat mode or if Fast Combat is enabled.
 
-![Wishes](https://i.imgur.com/SbgX3hk.png)
+![Wishes](https://i.imgur.com/g8nsInJ.png)
 
 - **Sort Wishes by Completion Time** - Each wish has a raw speed value that determines how fast it progresses. By default wishes are assigned to wish slots based on this speed (fastest wishes first). If this is checked, wishes will be assigned to slots by the remaining time to complete the current level of the wish instead. For example Wish 9 and Wish 10 both have the same raw speed, if this option is unchecked, Wish 9 will go to max level before any levels are gained in Wish 10. But since each additional level adds more time to the raw speed, if this option is checked, Wish 9 and 10 will gain levels equally.
 - **Priority Wishes** - The wishes to prioritize for the available wish slots. If there are open slots remaining after all prioritized wishes are assigned, other available wishes will be assigned to open slots ordered by the method outlined above.
 - **Sort Priority Wishes** - If unchecked, will assign wishes to wish slots based on their order in the Priority list. If checked, will order by the method outlined above.
 - **Blacklist Wishes** - Assign wishes you never want to cast here. Any which in this list will be ignored when working out the wish priorities. Supersedes Priority list if the same wish is in both lists.
 
-![The Pit](https://i.imgur.com/azmHcTH.png)
+![The Pit](https://i.imgur.com/vXvkQPT.png)
 
 - **Auto Daily Spin** - Automatically do daily spin and log the result to the loot.log file
 - **Auto Money Pit** - Automatically throw money into the money pit if the Money Pit Threshold is met. Logs the result to the loot.log file
 - **Money Pit Threshold** - The amount of gold to wait for to throw gold into the money pit. Accepts scientific notation (ex: 1E+28)
 - **Loadout** - Items to equip before throwing money in the pit
 
-![Cards](https://i.imgur.com/P1ng5D7.png)
+![Cards](https://i.imgur.com/b5G9O1Z.png)
 
 - **Manage Mayo** - Prioritize mayo production to be able to cast the first card in your deck asap. If you have no cards, it will equalize all mayo types.
 - **Auto Cast Cards** - Cast any card that is not trashed according to your settings.
@@ -247,9 +248,16 @@ This will place any protected cards first. For all the protected cards, it will 
 
 - **Auto Trash Cards** - Automatically yeet cards according to the settings below.
 - **Trash Adventure Cards** - If checked, adventure cards are yeeted according to your settings. If not checked, no adventure cards are ever yeeted, regarless of settings.
+- **Trash Protected Cards** - If checked, protected cards are yeeted according to your settings. If not checked, no protected cards are ever yeeted, regarless of settings.
 - **Trash Cards of XXX quality/cost and below** - Yeet cards which are at or below the specified quality/cost.
 - **Trash Chonkers** - If checked, BigChonker level cards will be yeeted when on the Always Trash List. If not checked, BigChonker will not be yeeted unless settings specify you should Trash ALL BigChonker cards in the quality option.
 - **Trash All Cards of Type** Will trash ALL of these card types regardless of the quality/cost settings.
+
+![Cooking](https://i.imgur.com/2pgJoUZ.png)
+
+- **Manage Cooking** - Set this to true to have the injector optimize your cooking efficiency
+- **Swap Loadout for Cooking** - Set this to true to have the injector swap to a Cooking loadout when eating meals
+- **Loadout** - Items to equip before eating
 
 # Allocation
 


### PR DESCRIPTION
- New flag on Cards tab for users to decide if protected cards should be trashed
- Check the inventory (not accessories) when checking if we should trash an END card
- Fixed bug involving trashing protected END cards
- Cards are trashed in reverse order instead of trashing from the first to the last
- Prevent idling in ITOPOD in quest gear when sniping a titan zone
- Clarification on wording on titans tab